### PR TITLE
fix: 文件浏览器跨盘符路径选择报 Internal Server Error

### DIFF
--- a/src/amane/utils/path.py
+++ b/src/amane/utils/path.py
@@ -15,7 +15,12 @@ def is_descendant(p: str | Path, parent: str | Path) -> bool:
     p = os.path.realpath(p, strict=os.path.ALLOW_MISSING)
     parent = os.path.realpath(parent, strict=os.path.ALLOW_MISSING)
     # parent = /foo/bar, p = /foo/barbar 使得简单的前缀判断失效
-    return os.path.commonpath([p, parent]) == str(parent)
+    try:
+        common = os.path.commonpath([p, parent])
+    except ValueError:
+        # Windows 上 p, parent 来自不同盘符时 commonpath 抛 ValueError
+        return False
+    return common == str(parent)
 
 
 def is_any_descendant(p: str | Path, *parents: str | Path) -> bool:


### PR DESCRIPTION
## 问题

添加媒体库选择路径时，Windows 上浏览 E 盘路径返回 `Internal Server Error`（500），C 盘正常。

## 根因

`src/amane/utils/path.py` 的 `is_descendant` 用 `os.path.commonpath([p, parent])` 判断父子关系。Windows 上不同盘符（如 `C:\` 与 `D:\`）无公共路径，`commonpath` 会抛 `ValueError`；该异常未捕获，从 `/api/files`（目录浏览）与 `POST /libraries`（添加媒体库）冒泡成 500。

`is_any_descendant` 用 `any(...)` 逐个检查可信目录：即使 `E:\` 已在 `safe_dirs` 内，只要首个 parent 是 `C:\` 也会先抛错，循环到不了 `E:\`。

## 修复

跨盘（无公共根）视为非后代返回 `False`，让 `is_any_descendant` 跳过该盘、继续检查其余可信目录。

```python
try:
    common = os.path.commonpath([p, parent])
except ValueError:
    # Windows 上不同盘符 (C:\ 与 D:\) 无公共路径, commonpath 抛 ValueError
    return False
return common == str(parent)
```

## 测试

- 复用仓库已有的 Windows-only 用例 `test_is_descendant_windows`（含 `C:\Users\Test` 对比 `D:\Users` → `False`），仅在 Windows 上运行，Mac 上按惯例 skip。
- 本地 `just check` 全绿（lint / pyright / ty / web check / 全量 pytest）。

Fixes #1
