### PR TITLE
ci: lint 增加 ruff format --check

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -38,6 +38,7 @@ _web-install-ci:
 
 lint:
     uv run ruff check {{ CHECK_DIRS }}
+    uv run ruff format --check {{ CHECK_DIRS }}
 
 fix: fix-python fix-web
 


### PR DESCRIPTION
## 动机

本地 pre-commit 钩子会对 Python 做 `ruff format`, 但 CI 的 `just ci → check → lint` 只跑 `ruff check`, 不含格式检查 — 未格式化代码可以绕过 CI 进入 main (如 #19 合并时带出的 `tests/db/test_repository.py` 行折叠差异).

## 变更

- `Justfile` 的 `lint` 配方追加 `uv run ruff format --check {{ CHECK_DIRS }}`
- 当前树 382 个文件已全量格式化, 无一次性漂移需要修复

## 影响

- `just check` / `just ci` 从此把 Python 格式纳入门禁; 与前端 `pnpm check` 的 `oxfmt` 行为对齐
- 修复方式不变: `just fix` (ruff format 自动修)
