### PR TITLE
feat: strm 文件内容支持自定义模板

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.7.0
+
+### ✨ 新功能
+
+- **strm 文件内容支持自定义模板**: 媒体库新增 `strm 内容模板` (仅链接方式为 STRM 时生效), 可把 `.strm` 里的本地挂载路径换成 OpenList 侧路径或 HTTP 直链, 让 MediaWarp 的 AlistStrm / HTTPStrm 正确识别. 留空保持原行为 (写视频绝对路径), 存量库不受影响.
+  - 新增占位符 `{video_relpath}` (视频落地路径剔除**库根**前缀后的部分) 与 `{video_path}` (绝对路径). 二者取自视频**实际落地路径**, 自动带上分集后缀 (`-CD1`) 与重名时的 `(1)` 后缀
+  - 典型写法: 库根即挂载点时填 `/{video_relpath}`; 库根比挂载点深时补回缺的层级, 如 `/OD/VC/{video_relpath}`; Alist 子目录挂载填 `/OneDrive/{video_relpath}`; HTTPStrm 填 `http://alist:5244/d/{video_relpath}`
+  - 改完模板重跑「整理」即可刷新已生成的 strm, 无需先删文件
+
 ## v0.5.0
 
 ### ✨ 新功能

--- a/docs/dev/data-model.md
+++ b/docs/dev/data-model.md
@@ -1,6 +1,6 @@
 # 数据模型
 
-> 提交: `e41c7d8`
+> 提交: `e12269a`
 >
 > 表结构、字段类型、便捷属性都在 `src/amane/db/models.py`. 本文只解释**为什么**这么建模、所有权关系、生命周期与已知陷阱.
 
@@ -108,7 +108,7 @@ PATCH 三态: **省略键** = 不更新 (`exclude_unset`); **显式值** = 写�
 
 `link_template` 为空则不创建链接, `{link_dir}` 等于 `{video_dir}`. 非空时 ORGANIZE 在视频就位后按该模板写一条指向真实视频的入口: `link_mode=strm` 写 `.strm` (一行文本, 后缀强制 `.strm`); `symlink` 做文件系统软链接. 链接必须落在库根之外 (否则 REFRESH 会把 strm/软链接再扫成媒体). `{video_dir}` 始终是真实视频父目录; `{link_dir}` 是链接父目录. 默认附属模板用 `{link_dir}`, 因此填链接模板后 NFO/海报自动跟链接走, 不必改六个附属模板. 想把某类附属文件留在网盘侧, 显式写 `{video_dir}/…`.
 
-`strm_content_template` 决定 `.strm` 里那一行, 仅 `link_mode=strm` 生效, 空则写视频绝对路径 (存量库默认). 渲染在 `render_strm_content`, 独立于 `resolve_paths`: 输入必须是 `execute_organize` 的**实际 dest** 而非计划路径 — CD 后缀与碰撞改名 `(1)` 只体现在 dest 上, 用计划路径会让 strm 指向不存在的文件. 该函数**不走** `_render_template`: 结果是远端标识 (OpenList 路径 / HTTP URL) 而非本地路径, 做 `resolve()` 与库根边界校验只会把合法内容判成逃逸. 独占 `strm` 相位的两个占位符: `{video_path}` (dest 绝对路径) 与 `{video_relpath}` (dest 相对库根, POSIX 分隔符无前导 `/`, 由 `utils.path.relative_posix` 规范化两端后计算, 不用 `Path.relative_to` — 库根含符号链接时它会误判). 视频落在库根之外 (绝对 `video_template` 指向别的盘) 且模板引用了 `{video_relpath}` 时抛 `ValueError`, 由 `execute_file_operations` 转成链接失败 (dest 仍回写); 模板不引用则不报错. 校验只拒绝换行 (strm 是一行), 全空白收敛成 `None`. 内容与磁盘不一致时 `create_video_link` 直接覆盖重写, 所以改模板后重跑 ORGANIZE 即可刷新存量 strm.
+`strm_content_template` 决定 `.strm` 里那一行, 仅 `link_mode=strm` 生效, 空则写视频绝对路径 (存量库默认). 渲染在 `render_strm_content`, 独立于 `resolve_paths`: 输入必须是 `execute_organize` 的**实际 dest** 而非计划路径 — CD 后缀与碰撞改名 `(1)` 只体现在 dest 上, 用计划路径会让 strm 指向不存在的文件. 该函数**不走** `_render_template`: 结果是远端标识 (OpenList 路径 / HTTP URL) 而非本地路径, 做 `resolve()` 与库根边界校验只会把合法内容判成逃逸. 独占 `strm` 相位的两个占位符: `{video_path}` (dest 绝对路径) 与 `{video_relpath}` (dest 相对库根, POSIX 分隔符无前导 `/`, 由 `utils.path.relative_posix` 规范化两端后计算, 不用 `Path.relative_to` — 库根含符号链接时它会误判). **剔掉的是库根, 不是网盘挂载点**: 库根比挂载点深时 (挂载点 `/test`, 库根 `/test/OD/VC`) 中间层会一起被剔掉, 得在模板里补回 (`/OD/VC/{video_relpath}`) — 这是该占位符最常见的踩坑, 不做自动推断 (挂载点不可靠地从库根反推). 视频落在库根之外 (绝对 `video_template` 指向别的盘) 且模板引用了 `{video_relpath}` 时抛 `ValueError`, 由 `execute_file_operations` 转成链接失败 (dest 仍回写); 模板不引用则不报错. 校验只拒绝换行 (strm 是一行), 全空白收敛成 `None`. 内容与磁盘不一致时 `create_video_link` 直接覆盖重写, 所以改模板后重跑 ORGANIZE 即可刷新存量 strm.
 
 模板渲染在 `organize/path_templates.py::resolve_paths`. 占位符分相位: metadata 来自 Metadata 字段; `{raw_dir}` / `{raw_name}` (源文件父目录名 / 源文件名不含扩展名) 与 `{mosaic}` / `{definition}` (`parse_file_info` 从源路径检测) 只在 ORGANIZE 时注入, 不落库 (与 CD 检测同一约定); `{video_dir}` 为视频渲染后的父目录, `{link_dir}` 为链接渲染后的父目录 (未设链接时二者相同), 仅附属资源模板可用. `{raw_srt_name}` 仅字幕模板, 为该字幕原文件名不含扩展名; 字幕模板里的 `{ext}` 是该字幕自己的扩展名. `{mosaic}` 取值: 文件名标记 → 目录名整段词表 (由近到远; `uncensored` / `cracked` / 无码 / 破解 等, 子串不算) → content_type 兜底 `censored` (永不 `Unknown` — 有码/无码是全域语义, 保证目录名稳定). `{definition}` 只看文件名, 无命中回退 `Unknown` (与普通占位符一致). **幂等约束**: `{mosaic}` 放目录段且目录名等于词表时可二次读回; `{definition}` 与 CD 后缀必须仍能从**文件名**反推, 只放目录段会按默认值重排. 占位符相位与默认值由同模块导出, 经 `GET /api/libraries/path-template-schema` 下发, 前端不硬编码变量表.
 

--- a/docs/dev/data-model.md
+++ b/docs/dev/data-model.md
@@ -1,6 +1,6 @@
 # 数据模型
 
-> 提交: `9330fb5`
+> 提交: `e41c7d8`
 >
 > 表结构、字段类型、便捷属性都在 `src/amane/db/models.py`. 本文只解释**为什么**这么建模、所有权关系、生命周期与已知陷阱.
 
@@ -106,7 +106,9 @@ PATCH 三态: **省略键** = 不更新 (`exclude_unset`); **显式值** = 写�
 
 模板**故意按资源类型独立**, 而不是一个 `output_dir` + 后缀拼接 — 用户场景包括: NAS 多盘分存、字幕集中备份、NFO 同目录 vs 集中目录.
 
-`link_template` 为空则不创建链接, `{link_dir}` 等于 `{video_dir}`. 非空时 ORGANIZE 在视频就位后按该模板写一条指向真实视频的入口: `link_mode=strm` 写 `.strm` (内容为一行视频绝对路径, 后缀强制 `.strm`); `symlink` 做文件系统软链接. 链接必须落在库根之外 (否则 REFRESH 会把 strm/软链接再扫成媒体). `{video_dir}` 始终是真实视频父目录; `{link_dir}` 是链接父目录. 默认附属模板用 `{link_dir}`, 因此填链接模板后 NFO/海报自动跟链接走, 不必改六个附属模板. 想把某类附属文件留在网盘侧, 显式写 `{video_dir}/…`.
+`link_template` 为空则不创建链接, `{link_dir}` 等于 `{video_dir}`. 非空时 ORGANIZE 在视频就位后按该模板写一条指向真实视频的入口: `link_mode=strm` 写 `.strm` (一行文本, 后缀强制 `.strm`); `symlink` 做文件系统软链接. 链接必须落在库根之外 (否则 REFRESH 会把 strm/软链接再扫成媒体). `{video_dir}` 始终是真实视频父目录; `{link_dir}` 是链接父目录. 默认附属模板用 `{link_dir}`, 因此填链接模板后 NFO/海报自动跟链接走, 不必改六个附属模板. 想把某类附属文件留在网盘侧, 显式写 `{video_dir}/…`.
+
+`strm_content_template` 决定 `.strm` 里那一行, 仅 `link_mode=strm` 生效, 空则写视频绝对路径 (存量库默认). 渲染在 `render_strm_content`, 独立于 `resolve_paths`: 输入必须是 `execute_organize` 的**实际 dest** 而非计划路径 — CD 后缀与碰撞改名 `(1)` 只体现在 dest 上, 用计划路径会让 strm 指向不存在的文件. 该函数**不走** `_render_template`: 结果是远端标识 (OpenList 路径 / HTTP URL) 而非本地路径, 做 `resolve()` 与库根边界校验只会把合法内容判成逃逸. 独占 `strm` 相位的两个占位符: `{video_path}` (dest 绝对路径) 与 `{video_relpath}` (dest 相对库根, POSIX 分隔符无前导 `/`, 由 `utils.path.relative_posix` 规范化两端后计算, 不用 `Path.relative_to` — 库根含符号链接时它会误判). 视频落在库根之外 (绝对 `video_template` 指向别的盘) 且模板引用了 `{video_relpath}` 时抛 `ValueError`, 由 `execute_file_operations` 转成链接失败 (dest 仍回写); 模板不引用则不报错. 校验只拒绝换行 (strm 是一行), 全空白收敛成 `None`. 内容与磁盘不一致时 `create_video_link` 直接覆盖重写, 所以改模板后重跑 ORGANIZE 即可刷新存量 strm.
 
 模板渲染在 `organize/path_templates.py::resolve_paths`. 占位符分相位: metadata 来自 Metadata 字段; `{raw_dir}` / `{raw_name}` (源文件父目录名 / 源文件名不含扩展名) 与 `{mosaic}` / `{definition}` (`parse_file_info` 从源路径检测) 只在 ORGANIZE 时注入, 不落库 (与 CD 检测同一约定); `{video_dir}` 为视频渲染后的父目录, `{link_dir}` 为链接渲染后的父目录 (未设链接时二者相同), 仅附属资源模板可用. `{raw_srt_name}` 仅字幕模板, 为该字幕原文件名不含扩展名; 字幕模板里的 `{ext}` 是该字幕自己的扩展名. `{mosaic}` 取值: 文件名标记 → 目录名整段词表 (由近到远; `uncensored` / `cracked` / 无码 / 破解 等, 子串不算) → content_type 兜底 `censored` (永不 `Unknown` — 有码/无码是全域语义, 保证目录名稳定). `{definition}` 只看文件名, 无命中回退 `Unknown` (与普通占位符一致). **幂等约束**: `{mosaic}` 放目录段且目录名等于词表时可二次读回; `{definition}` 与 CD 后缀必须仍能从**文件名**反推, 只放目录段会按默认值重排. 占位符相位与默认值由同模块导出, 经 `GET /api/libraries/path-template-schema` 下发, 前端不硬编码变量表.
 

--- a/docs/dev/task-system.md
+++ b/docs/dev/task-system.md
@@ -1,6 +1,6 @@
 # 任务系统
 
-> 提交: `9330fb5`
+> 提交: `e41c7d8`
 >
 > 入口: `src/amane/handlers/`, `src/amane/scheduler/worker.py`. Payload 结构、handler 步骤都在源码; 本文只解释**为什么**这么编排.
 > 数据所有权见 [data-model.md](data-model.md), 启动顺序见 [architecture.md](architecture.md), 日志隔离见 [observability.md](observability.md).
@@ -114,7 +114,7 @@ handler 之间复用的阶段逻辑, 不是一条可跳步的总管线:
 - **整理 = 复制到库路径**: 优先用 Resource 已有文件; 缺失才现场 `acquire`. 复制哪些类型由 Library.`copy_resources` (或 ORGANIZE payload 覆盖) 决定, 不由 `scraping.download_resources` 控制.
 - **海报缺失**: 按 `scraping.crop_poster` 从已落盘 thumb 裁剪兜底.
 - **已就位**: 源与模板 dest 已是同一文件 (含硬链) 时视为成功, 不追加 `(1)`; 碰撞改名只用于 dest 被另一文件占用.
-- **链接入口**: `link_template` 非空时, 视频就位后在库根之外写 strm 或软链接, 指向这次的 dest. `MediaFile.path` 仍是真实视频. 链接写入失败时 dest 仍回写 (视频已搬家), 任务记失败以便重试补链接.
+- **链接入口**: `link_template` 非空时, 视频就位后在库根之外写 strm 或软链接, 指向这次的 dest. `MediaFile.path` 仍是真实视频. strm 内容由 `strm_content_template` 就着**这次的 dest** 渲染 (空模板即 dest 绝对路径), 渲染失败与链接写入失败同处理: dest 仍回写 (视频已搬家), 任务记失败以便重试补链接.
 - **失效索引**: ORGANIZE 落盘前按库删除 path 在磁盘上不存在的 MediaFile. 碰撞改名只看磁盘; 不先清幽灵行会让 dest(1) 在 UNIQUE 上撞库内旧 path.
 
 ## 刮削期资源物化

--- a/docs/user/libraries.md
+++ b/docs/user/libraries.md
@@ -31,6 +31,8 @@
 | `{video_dir}` | 按模板渲染后目标文件所在目录的路径，仅可用于附属资源模板 | — |
 | `{link_dir}` | 链接文件渲染后的父目录 (无链接时等于 video_dir) | — |
 | `{raw_srt_name}` | 字幕原文件名，不含扩展名，仅字幕模板 | `foo.zh.srt` → `foo.zh` |
+| `{video_path}` | 整理后视频的绝对路径，仅 strm 内容模板 | `/test/OD/VC/MIDV-123/MIDV-123.mp4` |
+| `{video_relpath}` | 整理后视频相对库根的路径 (POSIX 分隔符，无前导 `/`)，仅 strm 内容模板 | `OD/VC/MIDV-123/MIDV-123.mp4` |
 
 ### 默认模板
 
@@ -64,8 +66,9 @@ NFO: {link_dir}/{number}.nfo
 
 - **`link_template`**: 链接文件的路径模板 (如 `/本地路径/{number}/{number}`). 为空则不创建链接, `{link_dir}` 等于 `{video_dir}`.
 - **`link_mode`**: 链接类型
-  - `strm`: 创建 `.strm` 文件 (内容为视频绝对路径), Emby/Jellyfin 可识别
+  - `strm`: 创建 `.strm` 文件 (内容默认为视频绝对路径), Emby/Jellyfin 可识别
   - `symlink`: 创建文件系统软链接
+- **`strm_content_template`**: `.strm` 文件的内容模板 (单行), 仅 `link_mode=strm` 生效. 为空则写视频绝对路径.
 
 ### 使用场景
 
@@ -74,6 +77,28 @@ NFO: {link_dir}/{number}.nfo
 - 视频在挂载盘上按模板改名
 - 本地出现 strm 文件或软链接 + NFO/海报
 - 媒体服务器扫描本地路径即可
+
+### strm 内容: 对齐 OpenList / MediaWarp
+
+默认写的是**本地挂载点**上的绝对路径. 用 rclone 挂载 OpenList 时, 这条路径与 OpenList 上的文件路径差一个挂载前缀,
+MediaWarp 的 **AlistStrm** 认不出来. 此时填 `strm_content_template` 把库根前缀换掉:
+
+| 库路径 (rclone 挂载点) | 视频落地 | strm 内容模板 | strm 内容 |
+|---|---|---|---|
+| `/test` (挂 OpenList 根) | `/test/OD/VC/MIDV-123/MIDV-123.mp4` | `/{video_relpath}` | `/OD/VC/MIDV-123/MIDV-123.mp4` |
+| `/test` (挂 OpenList `/OneDrive`) | 同上 | `/OneDrive/{video_relpath}` | `/OneDrive/OD/VC/MIDV-123/MIDV-123.mp4` |
+| `/test` (HTTPStrm 直链) | 同上 | `http://alist:5244/d/{video_relpath}` | `http://alist:5244/d/OD/VC/MIDV-123/MIDV-123.mp4` |
+
+!!! tip
+    优先用 `{video_relpath}` 而不是手写 `/OD/VC/{number}/{number}.{ext}`.
+    `{video_relpath}` 取自视频**实际落地路径**, 自动带上分集后缀 (`-CD1`) 与重名时的 `(1)` 后缀;
+    手写元数据占位符会丢掉这两者, 让 strm 指向不存在的文件.
+
+!!! note
+    改完模板重跑「整理」即可刷新已生成的 strm — 内容不同会直接覆盖重写, 不需要先删文件.
+    模板不能含换行 (strm 是一行路径), 保存时会拒绝.
+    若 `video_template` 用绝对路径把视频放到了库根之外 (多盘分存), `{video_relpath}` 无解,
+    该文件整理会记失败并给出明确错误, 而不是写出一个错的 strm.
 
 !!! note
     链接路径必须在库根之外, 否则会被扫描为新文件. `{link_dir}` 占位符在有链接时指向链接父目录, 默认的 NFO/海报模板已改用 `{link_dir}`, 因此填写链接模板后附属文件自动跟随, 无需修改其他模板.

--- a/docs/user/libraries.md
+++ b/docs/user/libraries.md
@@ -32,7 +32,7 @@
 | `{link_dir}` | 链接文件渲染后的父目录 (无链接时等于 video_dir) | — |
 | `{raw_srt_name}` | 字幕原文件名，不含扩展名，仅字幕模板 | `foo.zh.srt` → `foo.zh` |
 | `{video_path}` | 整理后视频的绝对路径，仅 strm 内容模板 | `/test/OD/VC/MIDV-123/MIDV-123.mp4` |
-| `{video_relpath}` | 整理后视频相对库根的路径 (POSIX 分隔符，无前导 `/`)，仅 strm 内容模板 | `OD/VC/MIDV-123/MIDV-123.mp4` |
+| `{video_relpath}` | 整理后视频路径**自动剔除库根前缀**后的部分 (POSIX 分隔符，无前导 `/`)，仅 strm 内容模板 | 库根 `/test` 时 → `OD/VC/MIDV-123/MIDV-123.mp4` |
 
 ### 默认模板
 
@@ -69,6 +69,7 @@ NFO: {link_dir}/{number}.nfo
   - `strm`: 创建 `.strm` 文件 (内容默认为视频绝对路径), Emby/Jellyfin 可识别
   - `symlink`: 创建文件系统软链接
 - **`strm_content_template`**: `.strm` 文件的内容模板 (单行), 仅 `link_mode=strm` 生效. 为空则写视频绝对路径.
+  `{video_relpath}` 会自动剔除库根前缀, 库根比挂载点深时请在模板里补回缺的层级 (见下).
 
 ### 使用场景
 
@@ -80,17 +81,26 @@ NFO: {link_dir}/{number}.nfo
 
 ### strm 内容: 对齐 OpenList / MediaWarp
 
-默认写的是**本地挂载点**上的绝对路径. 用 rclone 挂载 OpenList 时, 这条路径与 OpenList 上的文件路径差一个挂载前缀,
-MediaWarp 的 **AlistStrm** 认不出来. 此时填 `strm_content_template` 把库根前缀换掉:
+默认写的是**本地**绝对路径. 用 rclone 挂载 OpenList 时, 这条路径与 OpenList 上的文件路径差一个挂载前缀,
+MediaWarp 的 **AlistStrm** 认不出来. 填 `strm_content_template` 换掉这个前缀:
 
-| 库路径 (rclone 挂载点) | 视频落地 | strm 内容模板 | strm 内容 |
-|---|---|---|---|
-| `/test` (挂 OpenList 根) | `/test/OD/VC/MIDV-123/MIDV-123.mp4` | `/{video_relpath}` | `/OD/VC/MIDV-123/MIDV-123.mp4` |
-| `/test` (挂 OpenList `/OneDrive`) | 同上 | `/OneDrive/{video_relpath}` | `/OneDrive/OD/VC/MIDV-123/MIDV-123.mp4` |
-| `/test` (HTTPStrm 直链) | 同上 | `http://alist:5244/d/{video_relpath}` | `http://alist:5244/d/OD/VC/MIDV-123/MIDV-123.mp4` |
+**`{video_relpath}` = 视频落地路径自动剔除「库根」之后的部分.** 剔掉的是**库根**, 不是挂载点 —— 两者相同时直接可用,
+库根更深时少掉的层级要自己在模板里补:
+
+| 库根 (媒体库的「路径」) | `video_template` | 视频落地 | strm 内容模板 | strm 内容 |
+|---|---|---|---|---|
+| `/test` (= 挂载点) | `OD/VC/{number}/{number}.{ext}` | `/test/OD/VC/MIDV-123/MIDV-123.mp4` | `/{video_relpath}` | `/OD/VC/MIDV-123/MIDV-123.mp4` |
+| `/test/OD/VC` (比挂载点深) | `{number}/{number}.{ext}` | 同上 | `/OD/VC/{video_relpath}` | `/OD/VC/MIDV-123/MIDV-123.mp4` |
+| `/test` + Alist 子目录挂载 | `OD/VC/{number}/{number}.{ext}` | 同上 | `/OneDrive/{video_relpath}` | `/OneDrive/OD/VC/MIDV-123/MIDV-123.mp4` |
+| `/test` + HTTPStrm 直链 | `OD/VC/{number}/{number}.{ext}` | 同上 | `http://alist:5244/d/{video_relpath}` | `http://alist:5244/d/OD/VC/MIDV-123/MIDV-123.mp4` |
+
+!!! warning "库根比挂载点深时前缀会连带被剔掉"
+    库根 `/test/OD/VC` 时, `OD/VC` 属于库根的一部分, `{video_relpath}` 只剩 `MIDV-123/MIDV-123.mp4`,
+    strm 内容会变成 `/MIDV-123/MIDV-123.mp4` —— OpenList 上找不到.
+    模板前面补 `/OD/VC/` 即可, 无需改库根 (改库根会连带影响扫描范围, 且 `video_template` 也得跟着改).
 
 !!! tip
-    优先用 `{video_relpath}` 而不是手写 `/OD/VC/{number}/{number}.{ext}`.
+    要拼进文件名时, 优先用 `{video_relpath}` 而不是手写 `/OD/VC/{number}/{number}.{ext}`.
     `{video_relpath}` 取自视频**实际落地路径**, 自动带上分集后缀 (`-CD1`) 与重名时的 `(1)` 后缀;
     手写元数据占位符会丢掉这两者, 让 strm 指向不存在的文件.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "amane"
-version = "0.5.0"
+version = "0.6.0"
 description = "Amane — media metadata management service"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "amane"
-version = "0.6.0"
+version = "0.7.0"
 description = "Amane — media metadata management service"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/amane/agent/library_ops.py
+++ b/src/amane/agent/library_ops.py
@@ -27,6 +27,7 @@ _LIBRARY_UPDATE_KEYS = frozenset(
         "video_template",
         "link_template",
         "link_mode",
+        "strm_content_template",
         "cd_suffix_template",
         "thumb_template",
         "poster_template",

--- a/src/amane/api/models/libraries.py
+++ b/src/amane/api/models/libraries.py
@@ -4,7 +4,12 @@ from pydantic import BaseModel, Field
 
 from ...db import Library
 from ...enums import DownloadableResource, LibraryAutomation, LinkMode, MoveMode
-from ...organize.path_templates import CD_SUFFIX_TEMPLATE_DEFAULT, CdSuffixTemplate, PlaceholderPhase
+from ...organize.path_templates import (
+    CD_SUFFIX_TEMPLATE_DEFAULT,
+    CdSuffixTemplate,
+    PlaceholderPhase,
+    StrmContentTemplate,
+)
 from ...utils.extensions import (
     DEFAULT_SUBTITLE_EXTENSIONS,
     DEFAULT_TRAILER_PATTERN,
@@ -27,6 +32,8 @@ class LibraryCreateRequest(BaseModel):
     video_template: str = "{studio}/{number}/{number}.{ext}"
     link_template: str | None = None
     link_mode: LinkMode = LinkMode.STRM
+    strm_content_template: StrmContentTemplate = None
+    """strm 内容模板 (单行), 仅 link_mode=strm 生效; 空则写视频绝对路径."""
     cd_suffix_template: CdSuffixTemplate = CD_SUFFIX_TEMPLATE_DEFAULT
     thumb_template: str | None = None
     poster_template: str | None = None
@@ -64,6 +71,7 @@ class LibraryResponse(BaseModel):
     video_template: str
     link_template: str | None = None
     link_mode: LinkMode
+    strm_content_template: str | None = None
     cd_suffix_template: str
     thumb_template: str | None = None
     poster_template: str | None = None

--- a/src/amane/api/routes/libraries.py
+++ b/src/amane/api/routes/libraries.py
@@ -58,6 +58,7 @@ async def create_library(req: LibraryCreateRequest, repo: RepoDep, runtime: Runt
         video_template=req.video_template,
         link_template=req.link_template,
         link_mode=req.link_mode,
+        strm_content_template=req.strm_content_template,
         cd_suffix_template=req.cd_suffix_template,
         thumb_template=req.thumb_template,
         poster_template=req.poster_template,

--- a/src/amane/db/migrations/versions/28e5bb3b529b_library_strm_content_template.py
+++ b/src/amane/db/migrations/versions/28e5bb3b529b_library_strm_content_template.py
@@ -1,0 +1,28 @@
+"""library strm content template
+
+Revision ID: 28e5bb3b529b
+Revises: 099436e749d6
+Create Date: 2026-08-29 19:38:49.980207
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "28e5bb3b529b"
+down_revision: str | None = "099436e749d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 存量行留 NULL: 与 link_template 同语义, 即「写视频绝对路径」的原行为.
+    with op.batch_alter_table("libraries") as batch_op:
+        batch_op.add_column(sa.Column("strm_content_template", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("libraries") as batch_op:
+        batch_op.drop_column("strm_content_template")

--- a/src/amane/db/models.py
+++ b/src/amane/db/models.py
@@ -329,8 +329,9 @@ class Library(SQLModel, table=True):
     strm_content_template: StrmContentTemplate = Field(default=None, sa_column=Column(String, nullable=True))
     """strm 文件内容模板 (单行), 仅 link_mode=strm 生效; 空则写视频绝对路径.
 
-    网盘场景用 {video_relpath} (视频相对库根的 POSIX 路径) 拼出远端标识, 使 strm 内容对齐
-    OpenList 上的文件而非 rclone 挂载点路径. 手写 {number} 等元数据占位符会丢 CD 后缀与碰撞改名.
+    网盘场景用 {video_relpath} (视频落地路径剔除**库根**前缀后的部分) 拼出远端标识, 使 strm 内容对齐
+    OpenList 上的文件而非 rclone 挂载点路径. 剔的是库根不是挂载点 — 库根更深时缺的层级要在模板里补回.
+    手写 {number} 等元数据占位符会丢 CD 后缀与碰撞改名.
     """
     cd_suffix_template: CdSuffixTemplate = Field(
         default=CD_SUFFIX_TEMPLATE_DEFAULT,

--- a/src/amane/db/models.py
+++ b/src/amane/db/models.py
@@ -6,7 +6,7 @@ from sqlalchemy import Column, Index, String, Text, UniqueConstraint, text
 from sqlmodel import JSON, Field, SQLModel
 
 from amane.enums import ActorGender, DownloadableResource, LibraryAutomation, LinkMode, MoveMode
-from amane.organize.path_templates import CD_SUFFIX_TEMPLATE_DEFAULT, CdSuffixTemplate
+from amane.organize.path_templates import CD_SUFFIX_TEMPLATE_DEFAULT, CdSuffixTemplate, StrmContentTemplate
 from amane.utils.extensions import (
     DEFAULT_SUBTITLE_EXTENSIONS,
     DEFAULT_TRAILER_PATTERN,
@@ -325,7 +325,13 @@ class Library(SQLModel, table=True):
     link_template: str | None = None
     """空则不创建链接. 非空时 ORGANIZE 在视频就位后按此模板写 strm 或软链接, 必须落在库根之外."""
     link_mode: LinkMode = Field(default=LinkMode.STRM, sa_column=Column(String, nullable=False, server_default="strm"))
-    """link_template 非空时: strm 写 .strm 文本 (内容为视频绝对路径); symlink 做文件系统软链接."""
+    """link_template 非空时: strm 写 .strm 文本 (内容见 strm_content_template); symlink 做文件系统软链接."""
+    strm_content_template: StrmContentTemplate = Field(default=None, sa_column=Column(String, nullable=True))
+    """strm 文件内容模板 (单行), 仅 link_mode=strm 生效; 空则写视频绝对路径.
+
+    网盘场景用 {video_relpath} (视频相对库根的 POSIX 路径) 拼出远端标识, 使 strm 内容对齐
+    OpenList 上的文件而非 rclone 挂载点路径. 手写 {number} 等元数据占位符会丢 CD 后缀与碰撞改名.
+    """
     cd_suffix_template: CdSuffixTemplate = Field(
         default=CD_SUFFIX_TEMPLATE_DEFAULT,
         sa_column=Column(String, nullable=False, server_default=CD_SUFFIX_TEMPLATE_DEFAULT),

--- a/src/amane/db/repo_types.py
+++ b/src/amane/db/repo_types.py
@@ -267,6 +267,7 @@ class LibraryUpdates(TypedDict, total=False):
     video_template: str
     link_template: str | None
     link_mode: LinkMode
+    strm_content_template: str | None
     cd_suffix_template: str
     thumb_template: str | None
     poster_template: str | None

--- a/src/amane/db/repos/libraries.py
+++ b/src/amane/db/repos/libraries.py
@@ -8,6 +8,7 @@ from amane.organize.path_templates import (
     CD_SUFFIX_TEMPLATE_DEFAULT,
     normalize_link_template,
     validate_cd_suffix_template,
+    validate_strm_content_template,
 )
 from amane.utils.extensions import (
     DEFAULT_SUBTITLE_EXTENSIONS,
@@ -35,6 +36,7 @@ class LibrariesRepoMixin(RepositoryMixinBase):
         video_template: str = "{studio}/{number}/{number}.{ext}",
         link_template: str | None = None,
         link_mode: LinkMode = LinkMode.STRM,
+        strm_content_template: str | None = None,
         cd_suffix_template: str | None = None,
         thumb_template: str | None = None,
         poster_template: str | None = None,
@@ -62,6 +64,7 @@ class LibrariesRepoMixin(RepositoryMixinBase):
                 video_template=video_template,
                 link_template=normalize_link_template(link_template),
                 link_mode=link_mode,
+                strm_content_template=validate_strm_content_template(strm_content_template),
                 cd_suffix_template=validate_cd_suffix_template(
                     cd_suffix_template if cd_suffix_template is not None else CD_SUFFIX_TEMPLATE_DEFAULT
                 ),
@@ -164,6 +167,8 @@ class LibrariesRepoMixin(RepositoryMixinBase):
                 lib.link_template = normalize_link_template(updates["link_template"])
             if "link_mode" in updates:
                 lib.link_mode = updates["link_mode"]
+            if "strm_content_template" in updates:
+                lib.strm_content_template = validate_strm_content_template(updates["strm_content_template"])
             if "cd_suffix_template" in updates:
                 lib.cd_suffix_template = validate_cd_suffix_template(updates["cd_suffix_template"])
             if "thumb_template" in updates:

--- a/src/amane/handlers/file.py
+++ b/src/amane/handlers/file.py
@@ -14,7 +14,15 @@ from ..media import ResourceStore, crop_poster
 from ..media import write_nfo as write_nfo_file
 from ..media.pipeline import RESOURCE_URL_PREFIX
 from ..net.http import WebClient
-from ..organize import MoveMode, ResolvedPaths, discover_subtitles, execute_organize, place_subtitles, resolve_paths
+from ..organize import (
+    MoveMode,
+    ResolvedPaths,
+    discover_subtitles,
+    execute_organize,
+    place_subtitles,
+    render_strm_content,
+    resolve_paths,
+)
 from ..organize.link import create_video_link
 from ..parsing import FileInfo, parse_file_info
 from ..utils.extensions import MEDIA_EXTENSIONS, TRASH_DIRNAME, compile_skip_patterns, is_undersized_video
@@ -108,7 +116,16 @@ async def execute_file_operations(
     # 3. 视频就位后写链接 (strm / 软链接); 失败仍带 dest 以便回写 MediaFile.path
     if org_result.success and org_result.dest and paths.link is not None:
         mode = LinkMode(library.link_mode) if library is not None else LinkMode.STRM
-        link_result = create_video_link(org_result.dest, paths.link, mode)
+        strm_content: str | None = None
+        if mode == LinkMode.STRM and library is not None:
+            # 用实际 dest 而非 paths.video: CD 后缀与碰撞改名只体现在 dest 上.
+            try:
+                strm_content = render_strm_content(
+                    library, metadata, org_result.dest, source_path=source_path, file_info=info
+                )
+            except ValueError as e:
+                return FileOperationsResult(success=False, dest=org_result.dest, error=str(e))
+        link_result = create_video_link(org_result.dest, paths.link, mode, strm_content=strm_content)
         if not link_result.success:
             return FileOperationsResult(success=False, dest=org_result.dest, error=link_result.error)
 

--- a/src/amane/organize/__init__.py
+++ b/src/amane/organize/__init__.py
@@ -8,12 +8,15 @@ from .path_templates import (
     VIDEO_TEMPLATE_DEFAULT,
     CdSuffixTemplate,
     ResolvedPaths,
+    StrmContentTemplate,
     normalize_link_template,
     path_template_schema,
     render_cd_suffix,
+    render_strm_content,
     resolve_paths,
     resolve_subtitle_path,
     validate_cd_suffix_template,
+    validate_strm_content_template,
 )
 from .subtitles import discover_subtitles, place_subtitles
 
@@ -25,6 +28,7 @@ __all__ = [
     "MoveMode",
     "OrganizeResult",
     "ResolvedPaths",
+    "StrmContentTemplate",
     "create_video_link",
     "discover_subtitles",
     "execute_organize",
@@ -32,7 +36,9 @@ __all__ = [
     "path_template_schema",
     "place_subtitles",
     "render_cd_suffix",
+    "render_strm_content",
     "resolve_paths",
     "resolve_subtitle_path",
     "validate_cd_suffix_template",
+    "validate_strm_content_template",
 ]

--- a/src/amane/organize/link.py
+++ b/src/amane/organize/link.py
@@ -7,23 +7,27 @@ from amane.enums import LinkMode
 from .file import OrganizeResult
 
 
-def create_video_link(target: Path, link_path: Path, mode: LinkMode) -> OrganizeResult:
+def create_video_link(
+    target: Path, link_path: Path, mode: LinkMode, *, strm_content: str | None = None
+) -> OrganizeResult:
     """在 link_path 创建指向 target 的 strm 或软链接.
 
-    strm 内容是 target 的绝对路径 (一行 + 换行). 已就位则成功不改写.
+    strm 内容为 `strm_content` (一行 + 换行), 缺省是 target 的绝对路径; 由库
+    `strm_content_template` 渲染 (见 `path_templates.render_strm_content`), 用于网盘场景把
+    本地挂载路径换成远端标识. 内容一致则成功不改写, 不一致则覆盖 — 改模板后重跑 ORGANIZE 即可刷新.
     占用路径若不是可替换的链接产物 (已有 strm / 软链接) 则拒绝覆盖.
     """
     try:
         link_path.parent.mkdir(parents=True, exist_ok=True)
         if mode == LinkMode.STRM:
-            return _write_strm(target, link_path)
+            return _write_strm(strm_content if strm_content is not None else str(target), link_path)
         return _write_symlink(target, link_path)
     except OSError as e:
         return OrganizeResult(success=False, error=str(e))
 
 
-def _write_strm(target: Path, link_path: Path) -> OrganizeResult:
-    content = f"{target}\n"
+def _write_strm(target_ref: str, link_path: Path) -> OrganizeResult:
+    content = f"{target_ref}\n"
     if link_path.exists() and not link_path.is_symlink():
         if link_path.suffix.lower() == ".strm":
             if link_path.read_text(encoding="utf-8") == content:

--- a/src/amane/organize/path_templates.py
+++ b/src/amane/organize/path_templates.py
@@ -9,7 +9,7 @@ from pydantic import AfterValidator
 from ..enums import LinkMode
 from ..parsing.file_info import ContentType, FileInfo
 from ..utils.extensions import DEFAULT_SUBTITLE_EXTENSIONS
-from ..utils.path import is_any_descendant, is_descendant
+from ..utils.path import is_any_descendant, is_descendant, relative_posix
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -72,6 +72,28 @@ def normalize_link_template(value: str | None) -> str | None:
     return stripped or None
 
 
+def validate_strm_content_template(value: str | None) -> str | None:
+    """校验 strm 内容模板 (空白视为未设置, 此时写视频绝对路径).
+
+    strm 是一行路径/URL, 因此非空模板拒绝换行: 多行内容会让 Emby / MediaWarp 读出带尾巴的路径.
+    先 strip 再判, 与 validate_cd_suffix_template 一致 — 全空白 (含误粘的换行) 只是「清空」.
+
+    Raises:
+        ValueError: 非空模板含换行
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    if "\n" in stripped or "\r" in stripped:
+        raise ValueError("strm_content_template must be a single line")
+    return stripped
+
+
+StrmContentTemplate = Annotated[str | None, AfterValidator(validate_strm_content_template)]
+
+
 def render_cd_suffix(template: str, cd: int) -> str:
     """渲染 CD 后缀 (调用前提: cd 非 None 且模板非空; 校验已保证恰好一个 {cd})."""
     return template.format(cd=cd)
@@ -96,6 +118,7 @@ class PlaceholderPhase(StrEnum):
     - ``file``: 来自源路径 (``parse_file_info``, 整理时检测);
     - ``post_video``: 视频与链接路径渲染后注入 (附属资源模板).
     - ``subtitle``: 字幕源文件, 仅字幕模板 (``{raw_srt_name}``).
+    - ``strm``: 整理后真实视频的落地路径, 仅 strm 内容模板.
     """
 
     METADATA = "metadata"
@@ -103,6 +126,7 @@ class PlaceholderPhase(StrEnum):
     FILE = "file"
     POST_VIDEO = "post_video"
     SUBTITLE = "subtitle"
+    STRM = "strm"
 
 
 PLACEHOLDERS: tuple[tuple[str, PlaceholderPhase], ...] = (
@@ -123,6 +147,8 @@ PLACEHOLDERS: tuple[tuple[str, PlaceholderPhase], ...] = (
     ("video_dir", PlaceholderPhase.POST_VIDEO),
     ("link_dir", PlaceholderPhase.POST_VIDEO),
     ("raw_srt_name", PlaceholderPhase.SUBTITLE),
+    ("video_path", PlaceholderPhase.STRM),
+    ("video_relpath", PlaceholderPhase.STRM),
 )
 
 
@@ -384,3 +410,45 @@ def resolve_subtitle_path(
     variables["raw_srt_name"] = subtitle_source.stem
     template = library.subtitle_template or OPTIONAL_TEMPLATE_DEFAULTS["subtitle_template"]
     return _render_template(template, variables, base_path, safe_dirs)
+
+
+_VIDEO_RELPATH_TOKEN = "{video_relpath}"
+
+
+def render_strm_content(
+    library: Library,
+    metadata: Metadata,
+    video_path: Path,
+    *,
+    source_path: Path | None = None,
+    file_info: FileInfo | None = None,
+) -> str:
+    """渲染 .strm 的单行内容; 库未配 strm_content_template 时为视频绝对路径.
+
+    `video_path` 必须是 ORGANIZE 落地后的**实际**路径, 而非 `resolve_paths` 的计划路径 —
+    `{video_path}` / `{video_relpath}` 要带上 CD 后缀与碰撞改名, 否则 strm 指向不存在的文件.
+
+    刻意不走 `_render_template`: 结果是远端 (OpenList / HTTP) 标识而非本地路径, 做 `resolve()`
+    与库根边界校验只会把合法内容判成逃逸.
+
+    Raises:
+        ValueError: 模板引用 `{video_relpath}` 但视频不在库根之下 (绝对 video_template 落到别的盘)
+    """
+    template = library.strm_content_template
+    if template is None:
+        return str(video_path)
+
+    variables = _build_variables(
+        metadata, ext=video_path.suffix.lstrip("."), source_path=source_path, file_info=file_info
+    )
+    variables["video_path"] = str(video_path)
+    relpath = relative_posix(video_path, library.path)
+    if relpath is None:
+        if _VIDEO_RELPATH_TOKEN in template:
+            raise ValueError(
+                f"Cannot resolve {_VIDEO_RELPATH_TOKEN}: video '{video_path}' is not under library root "
+                f"'{library.path}'"
+            )
+    else:
+        variables["video_relpath"] = relpath
+    return template.format_map(_SafeDict(variables))

--- a/src/amane/utils/path.py
+++ b/src/amane/utils/path.py
@@ -40,3 +40,15 @@ def is_descendant(p: str | Path, parent: str | Path) -> bool:
 
 def is_any_descendant(p: str | Path, *parents: str | Path) -> bool:
     return any(is_descendant(p, parent) for parent in parents)
+
+
+def relative_posix(p: str | Path, parent: str | Path) -> str | None:
+    """p 相对 parent 的 POSIX 相对路径 (无前导 ``/``); p 不是 parent 的后代时返回 None.
+
+    与 ``Path.relative_to`` 的区别: 先经 ``_resolve_or_literal`` 规范化两端, 因此库根或目标
+    路径含符号链接、大小写不一致时仍能算出相对段; 且不抛异常, 由调用方决定越界语义.
+    结果恒用 ``/`` 分隔, 供拼接远端 (OpenList / HTTP) 路径.
+    """
+    if not is_descendant(p, parent):
+        return None
+    return os.path.relpath(_resolve_or_literal(p), _resolve_or_literal(parent)).replace(os.sep, "/")

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -51,6 +51,8 @@ class TestLibraries:
         assert phases["video_dir"] == "post_video"
         assert phases["link_dir"] == "post_video"
         assert phases["raw_srt_name"] == "subtitle"
+        assert phases["video_path"] == "strm"
+        assert phases["video_relpath"] == "strm"
         assert data["subtitle_extensions_default"] == list(DEFAULT_SUBTITLE_EXTENSIONS)
 
         target = safe_path / "incoming"
@@ -67,6 +69,7 @@ class TestLibraries:
         assert body["move_mode"] == "move"
         assert body["link_template"] is None
         assert body["link_mode"] == "strm"
+        assert body["strm_content_template"] is None
         assert body["write_nfo"] is True
         assert set(body["copy_resources"]) == {"thumb", "poster", "extrafanart", "trailer"}
         assert body["trailer_pattern"] == "(?i)trailer"
@@ -126,6 +129,7 @@ class TestLibraries:
                 "cd_suffix_template": "",
                 "link_template": str(safe_path / "emby" / "{number}" / "{number}.{ext}"),
                 "link_mode": "symlink",
+                "strm_content_template": "  /OD/{video_relpath}  ",
             },
         )
         assert patched.status_code == 200
@@ -140,6 +144,14 @@ class TestLibraries:
         assert pbody["cd_suffix_template"] == ""
         assert pbody["link_mode"] == "symlink"
         assert pbody["link_template"] == str(safe_path / "emby" / "{number}" / "{number}.{ext}")
+        assert pbody["strm_content_template"] == "/OD/{video_relpath}"
+
+        # 空串 = 清空 (前端把空输入编成 null, 后端把空白也收敛成 None)
+        for blank in ("", "   ", None):
+            blanked = await client.patch(f"libraries/{lib_id}", json={"strm_content_template": blank})
+            assert blanked.status_code == 200
+            assert blanked.json()["strm_content_template"] is None
+        assert (await client.patch(f"libraries/{lib_id}", json={"strm_content_template": "/a\n/b"})).status_code == 422
 
         cleared = await client.patch(f"libraries/{lib_id}", json={"patterns": []})
         assert cleared.status_code == 200
@@ -173,6 +185,9 @@ class TestLibraries:
         base = {"path": str(target), "scan": False}
         assert (await client.post("libraries", json={**base, "move_mode": "foobar"})).status_code == 422
         assert (await client.post("libraries", json={**base, "link_mode": "foobar"})).status_code == 422
+        assert (
+            await client.post("libraries", json={**base, "strm_content_template": "/OD/x\n/OD/y"})
+        ).status_code == 422
         assert (await client.post("libraries", json={**base, "trailer_pattern": "[unclosed"})).status_code == 422
         assert (
             await client.post("libraries", json={**base, "blacklist_patterns": ["广告", "(ads"]})

--- a/tests/api/test_schemas.py
+++ b/tests/api/test_schemas.py
@@ -56,6 +56,7 @@ class TestLibraryCreateRequest:
         assert req.move_mode == "move"
         assert req.link_mode == "strm"
         assert req.link_template is None
+        assert req.strm_content_template is None
         assert req.min_file_size == 0
 
     def test_full(self):

--- a/tests/db/test_library_organize_migration.py
+++ b/tests/db/test_library_organize_migration.py
@@ -201,3 +201,35 @@ def test_library_min_file_size_backfilled_for_existing_rows(tmp_path: Path) -> N
         assert row.min_file_size == 0
 
     engine.dispose()
+
+
+def test_library_strm_content_template_backfilled_for_existing_rows(tmp_path: Path) -> None:
+    """存量行迁移后 strm_content_template 为 NULL (= 写视频绝对路径的原行为)."""
+    db_path = tmp_path / "migrate.db"
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+
+    command.upgrade(cfg, "099436e749d6")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO libraries "
+                "(name, path, automation, recursive, patterns, move_mode, video_template, write_nfo, "
+                "copy_resources, trailer_pattern, blacklist_patterns, subtitle_extensions, link_mode, "
+                "min_file_size) "
+                "VALUES ('t', '/m', 'scrape', 1, '[]', 'move', '{number}.{ext}', 1, '[\"thumb\"]', "
+                "'(?i)trailer', '[]', '[\".srt\"]', 'strm', 0)"
+            )
+        )
+
+    command.upgrade(cfg, "head")
+
+    with engine.connect() as conn:
+        columns = {column["name"] for column in inspect(conn).get_columns("libraries")}
+        assert "strm_content_template" in columns
+        row = conn.execute(text("SELECT strm_content_template FROM libraries")).one()
+        assert row.strm_content_template is None
+
+    engine.dispose()

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -152,6 +152,7 @@ class TestLibrary:
         assert lib.move_mode == MoveMode.MOVE
         assert lib.link_template is None
         assert lib.link_mode == LinkMode.STRM
+        assert lib.strm_content_template is None
         assert lib.video_template == "/out/{studio}/{number}/{number}.{ext}"
         assert lib.write_nfo is True
         assert lib.copy_resources == [r for r in DownloadableResource if r != DownloadableResource.trailer]

--- a/tests/handlers/test_organize.py
+++ b/tests/handlers/test_organize.py
@@ -590,3 +590,94 @@ async def test_organize_writes_strm_and_nfo_next_to_link(
     updated = await repo.get_media_file(media.id)
     assert updated is not None
     assert updated.path == str(dest)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_organize_strm_content_template_writes_remote_path(
+    repo: Repository, resource_store: ResourceStore, tmp_path: Path
+) -> None:
+    """strm 内容按模板渲染成远端路径 (rclone 挂载点 → OpenList), 而不是本地绝对路径."""
+    lib_root = tmp_path / "lib"
+    local = tmp_path / "emby"
+    lib_root.mkdir()
+    local.mkdir()
+    src = lib_root / "incoming" / "NSFS-039.mp4"
+    src.parent.mkdir()
+    src.write_bytes(b"video")
+
+    lib = await repo.create_library(
+        name="t",
+        path=str(lib_root),
+        video_template="OD/VC/{number}/{number}.{ext}",
+        link_template=str(local / "{number}" / "{number}.{ext}"),
+        link_mode=LinkMode.STRM,
+        strm_content_template="/{video_relpath}",
+        copy_resources=[],
+    )
+    assert lib.id is not None
+    meta = await repo.upsert_metadata(number="NSFS-039", studio="Studio")
+    assert meta.id is not None
+    media = await repo.create_media_file(
+        lib.id, path=str(src), number="NSFS-039", status=MediaFileStatus.SCRAPED, metadata_id=meta.id
+    )
+    assert media.id is not None
+
+    org = OrganizeHandler(repo, HotSettings(), resource_store, safe_dirs=[tmp_path])
+    result = await org.handle(OrganizePayload(library_id=lib.id, path=str(src.parent)))
+    assert result.success is True
+    assert result.result is not None
+    assert result.result.organized == 1
+    assert result.result.failed == 0
+
+    dest = lib_root / "OD" / "VC" / "NSFS-039" / "NSFS-039.mp4"
+    strm = local / "NSFS-039" / "NSFS-039.strm"
+    assert dest.exists()
+    # 库根前缀被剥掉, 只留库内相对段 -- MediaWarp AlistStrm 需要的形态
+    assert strm.read_text(encoding="utf-8") == "/OD/VC/NSFS-039/NSFS-039.mp4\n"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_organize_strm_relpath_outside_library_root_fails(
+    repo: Repository, resource_store: ResourceStore, tmp_path: Path
+) -> None:
+    """视频经绝对模板落到库根之外时 {video_relpath} 无解: 记失败不写 strm, 但 dest 仍回写."""
+    lib_root = tmp_path / "lib"
+    disk2 = tmp_path / "disk2"
+    local = tmp_path / "emby"
+    for d in (lib_root, disk2, local):
+        d.mkdir()
+    src = lib_root / "incoming" / "NSFS-039.mp4"
+    src.parent.mkdir()
+    src.write_bytes(b"video")
+
+    lib = await repo.create_library(
+        name="t",
+        path=str(lib_root),
+        video_template=str(disk2 / "{number}" / "{number}.{ext}"),
+        link_template=str(local / "{number}" / "{number}.{ext}"),
+        link_mode=LinkMode.STRM,
+        strm_content_template="/{video_relpath}",
+        copy_resources=[],
+    )
+    assert lib.id is not None
+    meta = await repo.upsert_metadata(number="NSFS-039", studio="Studio")
+    assert meta.id is not None
+    media = await repo.create_media_file(
+        lib.id, path=str(src), number="NSFS-039", status=MediaFileStatus.SCRAPED, metadata_id=meta.id
+    )
+    assert media.id is not None
+
+    org = OrganizeHandler(repo, HotSettings(), resource_store, safe_dirs=[tmp_path])
+    result = await org.handle(OrganizePayload(library_id=lib.id, path=str(src.parent)))
+    assert result.success is True
+    assert result.result is not None
+    assert result.result.organized == 0
+    assert result.result.failed == 1
+
+    dest = disk2 / "NSFS-039" / "NSFS-039.mp4"
+    assert dest.exists()
+    assert not (local / "NSFS-039" / "NSFS-039.strm").exists()
+    # 视频已搬家, path 仍要回写, 否则索引指向空位
+    updated = await repo.get_media_file(media.id)
+    assert updated is not None
+    assert updated.path == str(dest)

--- a/tests/organize/test_file_org.py
+++ b/tests/organize/test_file_org.py
@@ -186,6 +186,58 @@ class TestCreateVideoLink:
         assert result.success is False
         assert occupied.read_text() == "nope"
 
+    def test_strm_writes_custom_content(self, tmp_path: Path):
+        """strm_content 覆盖默认的绝对路径 (网盘场景写远端标识)."""
+        target = tmp_path / "lib" / "A.mp4"
+        target.parent.mkdir()
+        target.write_text("video")
+        link = tmp_path / "emby" / "A.strm"
+        result = create_video_link(target, link, LinkMode.STRM, strm_content="/OD/VC/A.mp4")
+        assert result.success is True
+        assert link.read_text(encoding="utf-8") == "/OD/VC/A.mp4\n"
+
+    def test_strm_custom_content_idempotent(self, tmp_path: Path):
+        target = tmp_path / "A.mp4"
+        target.write_text("video")
+        link = tmp_path / "A.strm"
+        assert create_video_link(target, link, LinkMode.STRM, strm_content="/OD/A.mp4").success
+        assert create_video_link(target, link, LinkMode.STRM, strm_content="/OD/A.mp4").success
+        assert link.read_text(encoding="utf-8") == "/OD/A.mp4\n"
+
+    def test_strm_rewrites_when_content_changes(self, tmp_path: Path):
+        """改模板后重跑 ORGANIZE 应刷新存量 strm, 而不是保留旧内容."""
+        target = tmp_path / "A.mp4"
+        target.write_text("video")
+        link = tmp_path / "A.strm"
+        assert create_video_link(target, link, LinkMode.STRM).success
+        assert link.read_text(encoding="utf-8") == f"{target}\n"
+        assert create_video_link(target, link, LinkMode.STRM, strm_content="/OD/A.mp4").success
+        assert link.read_text(encoding="utf-8") == "/OD/A.mp4\n"
+        # 清空模板 (strm_content=None) 回退绝对路径
+        assert create_video_link(target, link, LinkMode.STRM).success
+        assert link.read_text(encoding="utf-8") == f"{target}\n"
+
+    def test_strm_custom_content_still_refuses_regular_file(self, tmp_path: Path):
+        """自定义内容不放宽覆盖保护: 非 strm 的占位文件仍拒绝覆盖."""
+        target = tmp_path / "A.mp4"
+        target.write_text("video")
+        occupied = tmp_path / "A.jpg"
+        occupied.write_text("nope")
+        result = create_video_link(target, occupied, LinkMode.STRM, strm_content="/OD/A.mp4")
+        assert result.success is False
+        assert occupied.read_text() == "nope"
+
+    def test_symlink_ignores_strm_content(self, tmp_path: Path):
+        """软链接没有"内容", strm_content 传了也不该影响链接目标."""
+        target = tmp_path / "lib" / "A.mp4"
+        target.parent.mkdir()
+        target.write_text("video")
+        link = tmp_path / "emby" / "A.mp4"
+        result = create_video_link(target, link, LinkMode.SYMLINK, strm_content="/OD/A.mp4")
+        assert result.success is True
+        assert result.dest is not None
+        assert result.dest.resolve() == target.resolve()
+
     @pytest.mark.skipif(sys.platform == "win32", reason="符号链接行为在 Windows 下不一致")
     def test_symlink_points_at_target(self, tmp_path: Path):
         target = tmp_path / "lib" / "A.mp4"

--- a/tests/organize/test_path_templates.py
+++ b/tests/organize/test_path_templates.py
@@ -15,9 +15,11 @@ from amane.enums import LinkMode
 from amane.organize import (
     CD_SUFFIX_TEMPLATE_DEFAULT,
     normalize_link_template,
+    render_strm_content,
     resolve_paths,
     resolve_subtitle_path,
     validate_cd_suffix_template,
+    validate_strm_content_template,
 )
 from amane.parsing import parse_file_info
 
@@ -559,3 +561,90 @@ class TestResolvePathsLink:
             safe_dirs=[other],
         )
         assert sub == other / "StudioX" / "ABC-123" / "MIDV-123.zh.srt"
+
+
+class TestValidateStrmContentTemplate:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (None, None),
+            ("", None),
+            ("   ", None),
+            ("\t\n ", None),  # 全空白视为清空, 其中的换行不触发拒绝
+            ("/{video_relpath}", "/{video_relpath}"),
+            ("  /OneDrive/{video_relpath}  ", "/OneDrive/{video_relpath}"),
+            ("http://alist:5244/d{video_relpath}", "http://alist:5244/d{video_relpath}"),
+        ],
+    )
+    def test_blank_is_unset_and_stripped(self, raw: str | None, expected: str | None):
+        assert validate_strm_content_template(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["/a\n/b", "/a\r/b", "/a\r\n/b", "/a\nb  "])
+    def test_multiline_rejected(self, raw: str):
+        """strm 是一行路径; 多行会让播放端读出带尾巴的路径."""
+        with pytest.raises(ValueError, match="single line"):
+            validate_strm_content_template(raw)
+
+
+class TestRenderStrmContent:
+    """strm 内容模板: 把本地挂载路径换成远端标识 (OpenList / HTTP)."""
+
+    def _lib(self, media: Path, template: str | None) -> Library:
+        return Library(name="t", path=str(media), strm_content_template=template)
+
+    def test_unset_writes_absolute_video_path(self, media: Path):
+        video = media / "OD" / "VC" / "ABC-123" / "ABC-123.mp4"
+        assert render_strm_content(self._lib(media, None), _meta(), video) == str(video)
+
+    @pytest.mark.parametrize(
+        ("template", "expected"),
+        [
+            ("/{video_relpath}", "/OD/VC/ABC-123/ABC-123.mp4"),
+            ("/OneDrive/{video_relpath}", "/OneDrive/OD/VC/ABC-123/ABC-123.mp4"),
+            ("http://alist:5244/d/{video_relpath}", "http://alist:5244/d/OD/VC/ABC-123/ABC-123.mp4"),
+            ("/OD/VC/{number}/{number}.{ext}", "/OD/VC/ABC-123/ABC-123.mp4"),
+            ("/{studio}/{video_relpath}", "/StudioX/OD/VC/ABC-123/ABC-123.mp4"),
+            ("/fixed/path.mp4", "/fixed/path.mp4"),  # 无占位符原样输出
+            ("/{nope}/{video_relpath}", "/Unknown/OD/VC/ABC-123/ABC-123.mp4"),  # 未知占位符回退 Unknown
+        ],
+    )
+    def test_renders_remote_reference(self, media: Path, template: str, expected: str):
+        video = media / "OD" / "VC" / "ABC-123" / "ABC-123.mp4"
+        assert render_strm_content(self._lib(media, template), _meta(), video) == expected
+
+    def test_video_path_is_absolute_local_path(self, media: Path):
+        video = media / "OD" / "ABC-123.mp4"
+        assert render_strm_content(self._lib(media, "{video_path}"), _meta(), video) == str(video)
+
+    def test_relpath_keeps_cd_suffix_and_collision_rename(self, media: Path):
+        """relpath 取自实际落地路径, 因此 CD 后缀与碰撞改名都保留 (手写元数据模板会丢)."""
+        lib = self._lib(media, "/{video_relpath}")
+        assert render_strm_content(lib, _meta(), media / "ABC-123" / "ABC-123-CD2.mp4") == "/ABC-123/ABC-123-CD2.mp4"
+        assert render_strm_content(lib, _meta(), media / "ABC-123" / "ABC-123(1).mp4") == "/ABC-123/ABC-123(1).mp4"
+
+    def test_ext_comes_from_landed_video(self, media: Path):
+        """{ext} 取实际落地文件的扩展名, 不需要调用方再传一份."""
+        content = render_strm_content(self._lib(media, "/{number}.{ext}"), _meta(), media / "ABC-123.mkv")
+        assert content == "/ABC-123.mkv"
+
+    def test_relpath_outside_library_root_raises(self, media: Path, other: Path):
+        """绝对 video_template 落到别的盘时 relpath 无意义, 宁可报错也不写出错误 strm."""
+        with pytest.raises(ValueError, match="not under library root"):
+            render_strm_content(self._lib(media, "/{video_relpath}"), _meta(), other / "ABC-123.mp4")
+
+    def test_outside_library_root_ok_when_relpath_unused(self, media: Path, other: Path):
+        """模板不引用 {video_relpath} 就不该因为视频在库外而失败."""
+        video = other / "ABC-123.mp4"
+        assert render_strm_content(self._lib(media, "{video_path}"), _meta(), video) == str(video)
+
+    def test_source_placeholders_available(self, media: Path):
+        """metadata / source / file 相位占位符一并可用."""
+        source = Path("/inbox/uncensored/ABC-123-4K.mp4")
+        content = render_strm_content(
+            self._lib(media, "/{mosaic}/{definition}/{raw_name}/{video_relpath}"),
+            _meta(),
+            media / "ABC-123.mp4",
+            source_path=source,
+            file_info=parse_file_info(source),
+        )
+        assert content == "/uncensored/4K/ABC-123-4K/ABC-123.mp4"

--- a/uv.lock
+++ b/uv.lock
@@ -54,7 +54,7 @@ wheels = [
 
 [[package]]
 name = "amane"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -54,7 +54,7 @@ wheels = [
 
 [[package]]
 name = "amane"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Amane API",
-    "version": "0.6.0"
+    "version": "0.7.0"
   },
   "paths": {
     "/api/health": {

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -7306,6 +7306,17 @@
             "$ref": "#/components/schemas/LinkMode",
             "default": "strm"
           },
+          "strm_content_template": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strm Content Template"
+          },
           "cd_suffix_template": {
             "type": "string",
             "title": "Cd Suffix Template",
@@ -7502,6 +7513,17 @@
           },
           "link_mode": {
             "$ref": "#/components/schemas/LinkMode"
+          },
+          "strm_content_template": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strm Content Template"
           },
           "cd_suffix_template": {
             "type": "string",
@@ -7738,6 +7760,17 @@
                 "type": "null"
               }
             ]
+          },
+          "strm_content_template": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strm Content Template"
           },
           "cd_suffix_template": {
             "anyOf": [
@@ -9240,10 +9273,11 @@
           "source",
           "file",
           "post_video",
-          "subtitle"
+          "subtitle",
+          "strm"
         ],
         "title": "PlaceholderPhase",
-        "description": "占位符相位: 值的来源与注入时机.\n\n- ``metadata``: 来自 Metadata 字段;\n- ``source``: 需 ``source_path`` (源文件父目录名 / 文件名);\n- ``file``: 来自源路径 (``parse_file_info``, 整理时检测);\n- ``post_video``: 视频与链接路径渲染后注入 (附属资源模板).\n- ``subtitle``: 字幕源文件, 仅字幕模板 (``{raw_srt_name}``)."
+        "description": "占位符相位: 值的来源与注入时机.\n\n- ``metadata``: 来自 Metadata 字段;\n- ``source``: 需 ``source_path`` (源文件父目录名 / 文件名);\n- ``file``: 来自源路径 (``parse_file_info``, 整理时检测);\n- ``post_video``: 视频与链接路径渲染后注入 (附属资源模板).\n- ``subtitle``: 字幕源文件, 仅字幕模板 (``{raw_srt_name}``).\n- ``strm``: 整理后真实视频的落地路径, 仅 strm 内容模板."
       },
       "PluginConfig": {
         "properties": {

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Amane API",
-    "version": "0.5.0"
+    "version": "0.6.0"
   },
   "paths": {
     "/api/health": {

--- a/web/src/client/schemas.gen.ts
+++ b/web/src/client/schemas.gen.ts
@@ -2474,6 +2474,17 @@ export const LibraryCreateRequestSchema = {
             $ref: '#/components/schemas/LinkMode',
             default: 'strm'
         },
+        strm_content_template: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Strm Content Template'
+        },
         cd_suffix_template: {
             type: 'string',
             title: 'Cd Suffix Template',
@@ -2672,6 +2683,17 @@ export const LibraryResponseSchema = {
         },
         link_mode: {
             $ref: '#/components/schemas/LinkMode'
+        },
+        strm_content_template: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Strm Content Template'
         },
         cd_suffix_template: {
             type: 'string',
@@ -2909,6 +2931,17 @@ export const LibraryUpdateRequestSchema = {
                     type: 'null'
                 }
             ]
+        },
+        strm_content_template: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Strm Content Template'
         },
         cd_suffix_template: {
             anyOf: [
@@ -4438,10 +4471,11 @@ export const PlaceholderPhaseSchema = {
         'source',
         'file',
         'post_video',
-        'subtitle'
+        'subtitle',
+        'strm'
     ],
     title: 'PlaceholderPhase',
-    description: '占位符相位: 值的来源与注入时机.\n\n- ``metadata``: 来自 Metadata 字段;\n- ``source``: 需 ``source_path`` (源文件父目录名 / 文件名);\n- ``file``: 来自源路径 (``parse_file_info``, 整理时检测);\n- ``post_video``: 视频与链接路径渲染后注入 (附属资源模板).\n- ``subtitle``: 字幕源文件, 仅字幕模板 (``{raw_srt_name}``).'
+    description: '占位符相位: 值的来源与注入时机.\n\n- ``metadata``: 来自 Metadata 字段;\n- ``source``: 需 ``source_path`` (源文件父目录名 / 文件名);\n- ``file``: 来自源路径 (``parse_file_info``, 整理时检测);\n- ``post_video``: 视频与链接路径渲染后注入 (附属资源模板).\n- ``subtitle``: 字幕源文件, 仅字幕模板 (``{raw_srt_name}``).\n- ``strm``: 整理后真实视频的落地路径, 仅 strm 内容模板.'
 } as const;
 
 export const PluginConfigSchema = {

--- a/web/src/client/types.gen.ts
+++ b/web/src/client/types.gen.ts
@@ -1223,6 +1223,10 @@ export type LibraryCreateRequest = {
     link_template?: string | null;
     link_mode?: LinkMode;
     /**
+     * Strm Content Template
+     */
+    strm_content_template?: string | null;
+    /**
      * Cd Suffix Template
      */
     cd_suffix_template?: string;
@@ -1330,6 +1334,10 @@ export type LibraryResponse = {
     link_template?: string | null;
     link_mode: LinkMode;
     /**
+     * Strm Content Template
+     */
+    strm_content_template?: string | null;
+    /**
      * Cd Suffix Template
      */
     cd_suffix_template: string;
@@ -1418,6 +1426,10 @@ export type LibraryUpdateRequest = {
      */
     link_template?: string | null;
     link_mode?: LinkMode | null;
+    /**
+     * Strm Content Template
+     */
+    strm_content_template?: string | null;
     /**
      * Cd Suffix Template
      */
@@ -2171,8 +2183,9 @@ export type PathTemplateSchemaResponse = {
  * - ``file``: 来自源路径 (``parse_file_info``, 整理时检测);
  * - ``post_video``: 视频与链接路径渲染后注入 (附属资源模板).
  * - ``subtitle``: 字幕源文件, 仅字幕模板 (``{raw_srt_name}``).
+ * - ``strm``: 整理后真实视频的落地路径, 仅 strm 内容模板.
  */
-export type PlaceholderPhase = 'metadata' | 'source' | 'file' | 'post_video' | 'subtitle';
+export type PlaceholderPhase = 'metadata' | 'source' | 'file' | 'post_video' | 'subtitle' | 'strm';
 
 /**
  * PluginConfig

--- a/web/src/components/library/library-form.tsx
+++ b/web/src/components/library/library-form.tsx
@@ -81,6 +81,7 @@ export interface LibraryFormState {
   move_mode: LibraryResponse["move_mode"];
   link_template: string;
   link_mode: LibraryResponse["link_mode"];
+  strm_content_template: string;
   write_nfo: boolean;
   copy_resources: DownloadableResource[];
   trailer_pattern: string;
@@ -110,6 +111,7 @@ export function emptyLibraryForm(schema?: PathTemplateSchemaResponse | null): Li
     move_mode: "move",
     link_template: "",
     link_mode: "strm",
+    strm_content_template: "",
     write_nfo: true,
     copy_resources: DOWNLOADABLE_RESOURCES.filter((r) => r !== "trailer"),
     trailer_pattern: "(?i)trailer",
@@ -141,6 +143,7 @@ export function libraryFormFromResponse(lib: LibraryResponse): LibraryFormState 
     move_mode: lib.move_mode,
     link_template: lib.link_template ?? "",
     link_mode: lib.link_mode,
+    strm_content_template: lib.strm_content_template ?? "",
     write_nfo: lib.write_nfo,
     copy_resources: parseCopyResources(lib.copy_resources),
     trailer_pattern: lib.trailer_pattern,
@@ -185,6 +188,7 @@ function libraryFormValues(form: LibraryFormState): Record<string, unknown> {
     move_mode: form.move_mode,
     link_template: form.link_template.trim(),
     link_mode: form.link_mode,
+    strm_content_template: form.strm_content_template.trim(),
     write_nfo: form.write_nfo,
     copy_resources: form.copy_resources,
     trailer_pattern: form.trailer_pattern,
@@ -378,6 +382,13 @@ export function LibraryFormFields({ value, onChange, showCreateOnly }: LibraryFo
           getLabel={(mode) => t(`linkMode.${mode}`)}
         />
       </FieldChrome>
+      <TextInput
+        label={t("fieldStrmContentTemplate")}
+        description={t("fieldStrmContentTemplateHint")}
+        placeholder={t("fieldStrmContentTemplatePlaceholder")}
+        value={value.strm_content_template}
+        onChange={(e) => onChange({ ...value, strm_content_template: e.currentTarget.value })}
+      />
 
       {placeholders.length > 0 && (
         <Stack gap={4}>

--- a/web/src/i18n/locales/en/library.json
+++ b/web/src/i18n/locales/en/library.json
@@ -135,7 +135,7 @@
   "fieldLinkMode": "Link Mode",
   "fieldLinkModeHint": "strm: write a .strm file (contents default to the video's absolute path; customizable below); symlink: a filesystem symlink to the mounted video",
   "fieldStrmContentTemplate": "STRM Content Template",
-  "fieldStrmContentTemplateHint": "Only applies when link mode is STRM. Leave empty to write the video's absolute path; when set, renders the single line inside the .strm, e.g. to swap an rclone mount path for the OpenList path (MediaWarp AlistStrm). Must not contain newlines",
+  "fieldStrmContentTemplateHint": "Only applies when link mode is STRM. Empty = write the video's absolute path. Otherwise renders the single line inside the .strm, to match OpenList / MediaWarp AlistStrm. Note {video_relpath} strips the library root, not the mount point — if the root is deeper than the mount point, add the missing segments yourself (root /test/OD/VC → use /OD/VC/{video_relpath}). Must not contain newlines",
   "fieldStrmContentTemplatePlaceholder": "e.g. /{video_relpath} or http://alist:5244/d/OneDrive/{video_relpath}",
   "linkMode": {
     "strm": "STRM file",
@@ -158,7 +158,7 @@
       "file": "From the source file name (detected during organize)",
       "post_video": "Available after video path is rendered; sidecar templates only",
       "subtitle": "From the subtitle source file; subtitle template only",
-      "strm": "Path of the organized video on disk; STRM content template only"
+      "strm": "Organized video path with the library root stripped; STRM content template only"
     },
     "items": {
       "number": "Catalog number",
@@ -179,7 +179,7 @@
       "link_dir": "Directory of the link file; same as {video_dir} when the link template is empty",
       "raw_srt_name": "Subtitle filename without extension. e.g. A/foo.zh.srt → foo.zh",
       "video_path": "Absolute path of the organized video (includes part suffix and collision rename); STRM content template only",
-      "video_relpath": "Organized video path relative to the library root, POSIX separators, no leading /; STRM content template only. e.g. root /test, video /test/OD/VC/ABC-123/ABC-123.mp4 → OD/VC/ABC-123/ABC-123.mp4"
+      "video_relpath": "Organized video path with the library root prefix stripped (POSIX separators, no leading /); STRM content template only. e.g. root /test → OD/VC/ABC-123/ABC-123.mp4; root /test/OD/VC → only ABC-123/ABC-123.mp4, so add /OD/VC/ in your template"
     }
   },
   "tpl": {

--- a/web/src/i18n/locales/en/library.json
+++ b/web/src/i18n/locales/en/library.json
@@ -133,7 +133,10 @@
   "fieldLinkTemplateHint": "Leave empty to skip. When set, organize writes a strm or symlink here pointing at the real video; must be an absolute path outside the library root",
   "fieldLinkTemplatePlaceholder": "e.g. /local/emby/{studio}/{number}/{number}.{ext}",
   "fieldLinkMode": "Link Mode",
-  "fieldLinkModeHint": "strm: write a .strm file whose contents are the video's absolute path; symlink: a filesystem symlink to the mounted video",
+  "fieldLinkModeHint": "strm: write a .strm file (contents default to the video's absolute path; customizable below); symlink: a filesystem symlink to the mounted video",
+  "fieldStrmContentTemplate": "STRM Content Template",
+  "fieldStrmContentTemplateHint": "Only applies when link mode is STRM. Leave empty to write the video's absolute path; when set, renders the single line inside the .strm, e.g. to swap an rclone mount path for the OpenList path (MediaWarp AlistStrm). Must not contain newlines",
+  "fieldStrmContentTemplatePlaceholder": "e.g. /{video_relpath} or http://alist:5244/d/OneDrive/{video_relpath}",
   "linkMode": {
     "strm": "STRM file",
     "symlink": "Symlink"
@@ -154,7 +157,8 @@
       "source": "From the source file (injected during organize)",
       "file": "From the source file name (detected during organize)",
       "post_video": "Available after video path is rendered; sidecar templates only",
-      "subtitle": "From the subtitle source file; subtitle template only"
+      "subtitle": "From the subtitle source file; subtitle template only",
+      "strm": "Path of the organized video on disk; STRM content template only"
     },
     "items": {
       "number": "Catalog number",
@@ -173,7 +177,9 @@
       "definition": "Resolution, from filename",
       "video_dir": "Directory of the rendered real video path; sidecar templates only",
       "link_dir": "Directory of the link file; same as {video_dir} when the link template is empty",
-      "raw_srt_name": "Subtitle filename without extension. e.g. A/foo.zh.srt → foo.zh"
+      "raw_srt_name": "Subtitle filename without extension. e.g. A/foo.zh.srt → foo.zh",
+      "video_path": "Absolute path of the organized video (includes part suffix and collision rename); STRM content template only",
+      "video_relpath": "Organized video path relative to the library root, POSIX separators, no leading /; STRM content template only. e.g. root /test, video /test/OD/VC/ABC-123/ABC-123.mp4 → OD/VC/ABC-123/ABC-123.mp4"
     }
   },
   "tpl": {

--- a/web/src/i18n/locales/zh-CN/library.json
+++ b/web/src/i18n/locales/zh-CN/library.json
@@ -129,7 +129,7 @@
   "fieldLinkMode": "链接方式",
   "fieldLinkModeHint": "strm：写 .strm 文件（内容默认为视频绝对路径，可用下方模板自定义）；软链接：在本地文件系统指向挂载盘上的视频",
   "fieldStrmContentTemplate": "STRM 内容模板",
-  "fieldStrmContentTemplateHint": "仅链接方式为 STRM 时生效。留空则写视频绝对路径；填写后按模板渲染 .strm 的单行内容，用于把 rclone 挂载路径换成 OpenList 等远端路径（MediaWarp AlistStrm）。不能含换行",
+  "fieldStrmContentTemplateHint": "仅链接方式为 STRM 时生效。留空 = 写视频绝对路径。填写后渲染成 .strm 的单行内容，用于对齐 OpenList / MediaWarp AlistStrm。注意 {video_relpath} 剔除的是「库根」而非挂载点，库根比挂载点深时请自行补回缺的层级（库根 /test/OD/VC → 填 /OD/VC/{video_relpath}）。不能含换行",
   "fieldStrmContentTemplatePlaceholder": "例如 /{video_relpath} 或 http://alist:5244/d/OneDrive/{video_relpath}",
   "linkMode": {
     "strm": "STRM 文件",
@@ -152,7 +152,7 @@
       "file": "来自源文件名（整理时检测）",
       "post_video": "视频路径渲染后可用，仅附属资源模板",
       "subtitle": "来自字幕源文件，仅字幕模板",
-      "strm": "整理后真实视频的落地路径，仅 STRM 内容模板"
+      "strm": "整理后真实视频的落地路径（剔除库根前缀），仅 STRM 内容模板"
     },
     "items": {
       "number": "番号",
@@ -173,7 +173,7 @@
       "link_dir": "链接文件所在目录；未设置链接模板时与 {video_dir} 相同",
       "raw_srt_name": "字幕原文件名，不含扩展名。例：A/foo.zh.srt → foo.zh",
       "video_path": "整理后真实视频的绝对路径（含 CD 后缀与碰撞改名），仅 STRM 内容模板",
-      "video_relpath": "整理后真实视频相对库根的路径，POSIX 分隔符、无前导 /，仅 STRM 内容模板。例：库根 /test，视频 /test/OD/VC/ABC-123/ABC-123.mp4 → OD/VC/ABC-123/ABC-123.mp4"
+      "video_relpath": "整理后真实视频的路径，自动剔除「库根」前缀（POSIX 分隔符、无前导 /），仅 STRM 内容模板。例：库根 /test → OD/VC/ABC-123/ABC-123.mp4；库根 /test/OD/VC → 只剩 ABC-123/ABC-123.mp4，需在模板里补 /OD/VC/"
     }
   },
   "tpl": {

--- a/web/src/i18n/locales/zh-CN/library.json
+++ b/web/src/i18n/locales/zh-CN/library.json
@@ -127,7 +127,10 @@
   "fieldLinkTemplateHint": "留空则不创建链接。设置后整理会在此路径写 strm 或软链接，指向库内真实视频；必须是库根之外的绝对路径",
   "fieldLinkTemplatePlaceholder": "例如 /local/emby/{studio}/{number}/{number}.{ext}",
   "fieldLinkMode": "链接方式",
-  "fieldLinkModeHint": "strm：写 .strm 文件（内容为视频绝对路径）；软链接：在本地文件系统指向挂载盘上的视频",
+  "fieldLinkModeHint": "strm：写 .strm 文件（内容默认为视频绝对路径，可用下方模板自定义）；软链接：在本地文件系统指向挂载盘上的视频",
+  "fieldStrmContentTemplate": "STRM 内容模板",
+  "fieldStrmContentTemplateHint": "仅链接方式为 STRM 时生效。留空则写视频绝对路径；填写后按模板渲染 .strm 的单行内容，用于把 rclone 挂载路径换成 OpenList 等远端路径（MediaWarp AlistStrm）。不能含换行",
+  "fieldStrmContentTemplatePlaceholder": "例如 /{video_relpath} 或 http://alist:5244/d/OneDrive/{video_relpath}",
   "linkMode": {
     "strm": "STRM 文件",
     "symlink": "软链接"
@@ -148,7 +151,8 @@
       "source": "来自源文件（整理时注入）",
       "file": "来自源文件名（整理时检测）",
       "post_video": "视频路径渲染后可用，仅附属资源模板",
-      "subtitle": "来自字幕源文件，仅字幕模板"
+      "subtitle": "来自字幕源文件，仅字幕模板",
+      "strm": "整理后真实视频的落地路径，仅 STRM 内容模板"
     },
     "items": {
       "number": "番号",
@@ -167,7 +171,9 @@
       "definition": "分辨率，从文件名检测",
       "video_dir": "按模板渲染后真实视频所在目录，仅可用于附属资源模板",
       "link_dir": "链接文件所在目录；未设置链接模板时与 {video_dir} 相同",
-      "raw_srt_name": "字幕原文件名，不含扩展名。例：A/foo.zh.srt → foo.zh"
+      "raw_srt_name": "字幕原文件名，不含扩展名。例：A/foo.zh.srt → foo.zh",
+      "video_path": "整理后真实视频的绝对路径（含 CD 后缀与碰撞改名），仅 STRM 内容模板",
+      "video_relpath": "整理后真实视频相对库根的路径，POSIX 分隔符、无前导 /，仅 STRM 内容模板。例：库根 /test，视频 /test/OD/VC/ABC-123/ABC-123.mp4 → OD/VC/ABC-123/ABC-123.mp4"
     }
   },
   "tpl": {


### PR DESCRIPTION
link_mode=strm 时 .strm 内容原本硬编码为视频本地绝对路径. 网盘场景下这是 rclone挂载点上的路径, 与 OpenList 上的文件路径差一个挂载前缀, MediaWarp 的 AlistStrm认不出来.

新增库级 strm_content_template (单行, 空则保持原行为), 独占 strm 相位的两个占位符:
- {video_relpath}: 视频相对库根的 POSIX 路径, 无前导 /
- {video_path}: 视频绝对路径

填 /{video_relpath} 即可把库根前缀换成 OpenList 侧路径; 加前缀或写成 URL 可覆盖AlistStrm 子目录挂载与 HTTPStrm.

渲染输入是 execute_organize 的实际 dest 而非计划路径, 因此 CD 后缀与碰撞改名自动带上. 视频落在库根外且模板引用 {video_relpath} 时报错, 不写出错误的 strm.