### PR TITLE
fix: 删除 Resource.last_accessed_at 以免缓存命中并发写库

### DIFF
--- a/src/amane/db/migrations/versions/54138fa1c160_drop_resources_last_accessed_at.py
+++ b/src/amane/db/migrations/versions/54138fa1c160_drop_resources_last_accessed_at.py
@@ -1,0 +1,27 @@
+"""drop resources last_accessed_at
+
+Revision ID: 54138fa1c160
+Revises: 05ee7dd4c06d
+Create Date: 2026-09-03 01:52:50.141302
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "54138fa1c160"
+down_revision: str | None = "05ee7dd4c06d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("resources") as batch_op:
+        batch_op.drop_column("last_accessed_at")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("resources") as batch_op:
+        batch_op.add_column(sa.Column("last_accessed_at", sa.DateTime(), nullable=True))

--- a/src/amane/db/models.py
+++ b/src/amane/db/models.py
@@ -460,7 +460,6 @@ class Resource(SQLModel, table=True):
     """派生/处理追溯. 裁剪: {'op':'crop','src':源url,'args':str};
     任意资源被超分后追加 {'sr': {tool,model,scale}}. 原始未处理图为 {}."""
     downloaded_at: datetime = Field(default_factory=_utcnow)
-    last_accessed_at: datetime | None = None
 
 
 # --- 分类索引 (爬取侧投影) ---

--- a/src/amane/media/resource_store.py
+++ b/src/amane/media/resource_store.py
@@ -13,7 +13,6 @@ import asyncio
 import hashlib
 import mimetypes
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -110,7 +109,7 @@ class ResourceStore:
         return self._base_dir.parent
 
     async def resolve(self, url: str) -> Path | None:
-        """查缓存, 命中且文件存在则返回路径. 更新 last_accessed_at."""
+        """查缓存, 命中且文件存在则返回路径."""
         async with self._session() as session:
             stmt = select(Resource).where(Resource.url == url)
             result = await session.exec(stmt)
@@ -126,10 +125,6 @@ class ResourceStore:
                 await session.commit()
                 return None
 
-            # 更新访问时间
-            record.last_accessed_at = datetime.now(UTC)
-            session.add(record)
-            await session.commit()
             return full_path
 
     async def acquire(self, url: str, client: WebClient) -> Path | None:
@@ -166,7 +161,7 @@ class ResourceStore:
         return dest
 
     async def get_by_url(self, url: str) -> Resource | None:
-        """按 url (locator key) 取 Resource 记录 (不触碰 last_accessed_at)."""
+        """按 url (locator key) 取 Resource 记录."""
         async with self._session() as session:
             result = await session.exec(select(Resource).where(Resource.url == url))
             return result.first()


### PR DESCRIPTION
> ❗ **此 PR 包含 DB migration**

## Summary
- 删除 `resources.last_accessed_at`。Resource 按引用回收，该列没有读者。
- 缓存命中不再写库，避免剧照 `gather` 并发 `acquire` 时同一事务先读后写触发 SQLite 快照冲突，导致 ORGANIZE 整任务失败。

## Test plan
- [ ] 迁移后 `resources` 表无 `last_accessed_at`
- [ ] 整理含剧照的媒体库时，缓存命中不再出现 `UPDATE resources SET last_accessed_at` / `database is locked`

Close #78