### PR TITLE
feat: 允许刮削时手填番号并关联媒体文件

### DIFF
--- a/docs/dev/crawlers.md
+++ b/docs/dev/crawlers.md
@@ -40,7 +40,8 @@ CrawlerFactory (缓存实例)
 | 进路 | 番号从哪来 | 会不会重写 |
 |------|------------|------------|
 | 扫库 / 按 `media_id` 刮削 | `parse_file_info(path).number` (`api/models/tasks.py` `ScrapeRequest.resolve`; REFRESH 同样) | **会.** 路径解析命中已知形态时改写成目录号: 插入 `-` (`HEYZO3607` → `HEYZO-3607`)、DMM 连写拆零 (`midv00123` → `MIDV-123`)、FC2/HEYZO 族规则、字母大写、剥 CD/字幕尾标. 规则只在 `parsing/file_info.py` `_match` / `_prepare`, 本文不抄表. |
-| 用户任务只填 `number` | submission 字符串 | **不会.** 原样进 payload; 空 `content_type` 只调用 `infer_content_type` 猜片种, 猜类型不改字符串. |
+| 用户任务只填 `number` | submission 字符串 | **不会.** 原样进 payload; 空 `content_type` 只调用 `infer_content_type` 推断内容类型, 不改字符串. |
+| 按 `media_id` 同时填写 `number` | submission 字符串 | **不会.** 原样进 payload; `media_id` 只关联文件. 空 `content_type` 按该番号推断, 不看文件路径. 空白 `number` 视为未填写, 回退到只按路径解析. |
 | RSS 自动入队 | `extract_number` (即 `parse_file_info(text=…)` ) | **会** (与路径同一套已知形态). 未命中则没有番号, **不会**把标题原文当番号. 源上若设了 `number_pattern` 则只走该正则, 见 [feeds.md](feeds.md). |
 
 落库 `Metadata.number` 也是这份 payload 原样 (UNIQUE 忽略大小写, 首次写入的大小写保留, 见 [data-model.md](data-model.md)). 因此补刮 / RESCRAPE 可能再次把无横线手填号送进爬虫.

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -23,7 +23,7 @@
 
 ## 列表分页
 
-片库 / 演员 / 分类的 **list**、订阅源、`/libraries/$id` 文件表走 `BrowsePageShell fill`: 标题/搜索不滚, 剩余高度交给 children. 视口高度是 `APP_SHELL_MAIN_HEIGHT` (header + 上下 padding), `/feeds` 阅读器、`/tasks` 与 `/logs` 共用, 不要再手写一份 calc. `/tasks` 页头 (状态/类型筛选) 留在 ListToolbar 外, 表体才走 ListToolbar; 阅读器虚滚自管, 不套 ListToolbar. 库详情的扫描/整理/配置/删除在 ListToolbar `trailing` (表体右上), 与左侧多选批处理相对.
+片库 / 演员 / 分类的 **list**、订阅源、`/libraries/$id` 文件表走 `BrowsePageShell fill`: 标题/搜索不滚, 剩余高度交给 children. 视口高度是 `APP_SHELL_MAIN_HEIGHT` (header + 上下 padding), `/feeds` 阅读器、`/tasks` 与 `/logs` 共用, 不要再手写一份 calc. `/tasks` 页头 (状态/类型筛选) 留在 ListToolbar 外, 表体才走 ListToolbar; 阅读器虚滚自管, 不套 ListToolbar. 库详情的扫描/整理/配置/删除在 ListToolbar `trailing` (表体右上), 与左侧多选批处理相对. 文件表行上的刷新图标只带 `media_id`; 「指定番号刮削」打开对话框, 番号必填、内容类型可选, 与 `media_id` 一同提交.
 
 `ListToolbar` 是表体壳: 顶栏 (多选 / 规则入口) 不滚, 表体内滚, **唯一**分页钉在视口底; 翻页把表体滚回顶部. `grid` / `cloud` 禁止 fill — 演员墙 `VirtuosoGrid` 用 `useWindowScroll`. ListToolbar 的 overflow 区要求父级有界高度; 非 fill 页拿它当壳, `flex` + `minHeight: 0` 会把表高塌成 0.
 

--- a/docs/dev/task-system.md
+++ b/docs/dev/task-system.md
@@ -171,7 +171,7 @@ handler 之间复用的阶段逻辑, 不是一条可跳步的总管线:
 
 两条路径形态不同, 不要混为一谈:
 
-**即时** (`POST /tasks`): 接收 `TaskSubmission` (含全部即时 `type`, 含 `actor_scrape` / `rescrape`), 经 `src/amane/api/support/task_resolve.py::resolve_submission` 得到 `(TaskType, Payload)` 后建 Task. REFRESH/ORGANIZE 只接受 `library_id`, resolve 时由 library 派生 `path`/`recursive`/`patterns` (submission 可显式覆盖); SCRAPE 走 number/media_id, **`content_type` 可空**: 为空时 media_id 按文件路径解析、number 按番号模式推断 (显式给定则覆盖). **`payload.number` 是否经过 `parse_file_info` 重写** 取决于进路 (路径会改写, 手填 `number` 原样), 爬虫必须两种都能吃, 见 [crawlers.md](crawlers.md) 番号入参. `ACTOR_SCRAPE` 走 `actor_id` (亦可通过 `POST /actors/{id}/scrape`).
+**即时** (`POST /tasks`): 接收 `TaskSubmission` (含全部即时 `type`, 含 `actor_scrape` / `rescrape`), 经 `src/amane/api/support/task_resolve.py::resolve_submission` 得到 `(TaskType, Payload)` 后建 Task. REFRESH/ORGANIZE 只接受 `library_id`, resolve 时由 library 派生 `path`/`recursive`/`patterns` (submission 可显式覆盖); SCRAPE 走 number/media_id, 二者可同时提交. **`content_type` 可空**: 为空时仅 media_id 按文件路径解析、有 number 时按番号推断 (显式给定则覆盖). **`payload.number` 是否经过 `parse_file_info` 重写** 取决于进路 (只按路径会改写, 手填 `number` 原样, 与 media_id 同时填写时仍原样), 爬虫必须两种都能吃, 见 [crawlers.md](crawlers.md) 番号入参. 覆盖只作用于这一次 `POST /tasks`; 库表一键刮削与 REFRESH 仍按路径解析. `ACTOR_SCRAPE` 走 `actor_id` (亦可通过 `POST /actors/{id}/scrape`).
 
 **定时** (`Schedule`): 仅接受 `RoutineSubmission` (`cleanup` / `upscale` / `r18_import` / `rescrape`). 创建时把 submission 的 `model_dump()` 原样写入 `Schedule.payload`; cron/trigger 触发时由 `CronScheduler._execute_task` 从 dict 构造对应 Payload 再建 Task. 编辑只改 name/cron/enabled; 改任务内容需删除重建.
 

--- a/src/amane/api/models/tasks.py
+++ b/src/amane/api/models/tasks.py
@@ -105,13 +105,10 @@ class TaskWorkerResponse(BaseModel):
 
 
 class ScrapeRequest(BaseModel):
-    number: str | None = Field(
-        default=None,
-        description="番号 (如 MIDV-123). 可与 media_id 同时提交: 此时用此字段刮削并关联该文件",
-    )
+    number: str | None = Field(default=None)
     media_id: int | None = Field(
         default=None,
-        description="MediaFile ID. 单独提交时从文件路径解析番号; 与 number 同时提交时只负责关联文件",
+        description="MediaFile ID. 通常仅用于内部提交任务，手动提交无需指定",
     )
     content_type: ContentType | None = Field(
         default=None,

--- a/src/amane/api/models/tasks.py
+++ b/src/amane/api/models/tasks.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 from typing import Annotated, Literal, Self
 
 from fastapi import HTTPException
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from ...db import Repository, TaskStatus, TaskType
 from ...handlers import (
@@ -105,22 +105,35 @@ class TaskWorkerResponse(BaseModel):
 
 
 class ScrapeRequest(BaseModel):
-    number: str | None = Field(default=None, description="番号 (如 MIDV-123); 与 media_id 互斥")
-    media_id: int | None = Field(default=None, description="MediaFile ID; 服务端从中读取 number, 与 number 互斥")
+    number: str | None = Field(
+        default=None,
+        description="番号 (如 MIDV-123). 可与 media_id 同时提交: 此时用此字段刮削并关联该文件",
+    )
+    media_id: int | None = Field(
+        default=None,
+        description="MediaFile ID. 单独提交时从文件路径解析番号; 与 number 同时提交时只负责关联文件",
+    )
     content_type: ContentType | None = Field(
-        default=None, description="内容类型; None = 服务端推断 (media_id 走文件路径解析, number 走番号模式)"
+        default=None,
+        description="内容类型; 未给出时: 仅 media_id 按文件路径推断, 有 number 时按番号推断",
     )
     use_cache: set[CacheKind] = Field(
         default_factory=lambda: {CacheKind.metadata, CacheKind.trans},
         description="启用的缓存种类 (metadata: 复用 DB per-site 快照; trans: 复用译文). 空集 = 全部强制刷新",
     )
 
+    @field_validator("number", mode="before")
+    @classmethod
+    def _normalize_number(cls, value: object) -> object:
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
+
     @model_validator(mode="after")
-    def _check_one_source(self):
+    def _check_source(self) -> Self:
         if self.number is None and self.media_id is None:
             raise ValueError("Either 'number' or 'media_id' must be provided")
-        if self.number is not None and self.media_id is not None:
-            raise ValueError("'number' and 'media_id' are mutually exclusive")
         return self
 
     async def resolve(self, repo: Repository) -> ScrapePayload:
@@ -129,6 +142,13 @@ class ScrapeRequest(BaseModel):
             media = await repo.get_media_file(self.media_id)
             if media is None:
                 raise HTTPException(status_code=404, detail=f"Media file {self.media_id} not found")
+            if self.number is not None:
+                return ScrapePayload(
+                    number=self.number,
+                    content_type=self.content_type or infer_content_type(self.number),
+                    media_file_id=self.media_id,
+                    use_cache=self.use_cache,
+                )
             parsed = parse_file_info(media.path)
             assert parsed.number is not None
             return ScrapePayload(
@@ -137,7 +157,6 @@ class ScrapeRequest(BaseModel):
                 media_file_id=self.media_id,
                 use_cache=self.use_cache,
             )
-        # number 必有 (validator 保证)
         assert self.number is not None
         return ScrapePayload(
             number=self.number,

--- a/tests/api/test_tasks.py
+++ b/tests/api/test_tasks.py
@@ -100,6 +100,29 @@ class TestSubmitTask:
         cached = await client.post("tasks", json={"type": "scrape", "media_id": media.id, "use_cache": ["trans"]})
         assert cached.json()["payload"]["use_cache"] == ["trans"]
 
+        override = await client.post("tasks", json={"type": "scrape", "media_id": media.id, "number": "MIDV-123"})
+        assert override.status_code == 202
+        assert override.json()["payload"]["number"] == "MIDV-123"
+        assert override.json()["payload"]["media_file_id"] == media.id
+        assert override.json()["payload"]["content_type"] == "censored"
+        forced_override = await client.post(
+            "tasks",
+            json={
+                "type": "scrape",
+                "media_id": media.id,
+                "number": "MIDV-123",
+                "content_type": "western",
+            },
+        )
+        assert forced_override.json()["payload"]["content_type"] == "western"
+        blank = await client.post("tasks", json={"type": "scrape", "media_id": media.id, "number": "   "})
+        assert blank.status_code == 202
+        assert blank.json()["payload"]["number"] == "MD-0123"
+        assert blank.json()["payload"]["content_type"] == "hentai"
+        missing = await client.post("tasks", json={"type": "scrape", "media_id": 9999, "number": "MIDV-123"})
+        assert missing.status_code == 404
+        assert (await client.post("tasks", json={"type": "scrape", "number": "   "})).status_code == 422
+
         cleanup = await client.post("tasks", json={"type": "cleanup"})
         assert cleanup.status_code == 202
         assert cleanup.json()["payload"]["remove_missing_files"] is True

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -10256,8 +10256,7 @@
                 "type": "null"
               }
             ],
-            "title": "Number",
-            "description": "番号 (如 MIDV-123). 可与 media_id 同时提交: 此时用此字段刮削并关联该文件"
+            "title": "Number"
           },
           "media_id": {
             "anyOf": [
@@ -10269,7 +10268,7 @@
               }
             ],
             "title": "Media Id",
-            "description": "MediaFile ID. 单独提交时从文件路径解析番号; 与 number 同时提交时只负责关联文件"
+            "description": "MediaFile ID. 通常仅用于内部提交任务，手动提交无需指定"
           },
           "content_type": {
             "anyOf": [

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -10257,7 +10257,7 @@
               }
             ],
             "title": "Number",
-            "description": "番号 (如 MIDV-123); 与 media_id 互斥"
+            "description": "番号 (如 MIDV-123). 可与 media_id 同时提交: 此时用此字段刮削并关联该文件"
           },
           "media_id": {
             "anyOf": [
@@ -10269,7 +10269,7 @@
               }
             ],
             "title": "Media Id",
-            "description": "MediaFile ID; 服务端从中读取 number, 与 number 互斥"
+            "description": "MediaFile ID. 单独提交时从文件路径解析番号; 与 number 同时提交时只负责关联文件"
           },
           "content_type": {
             "anyOf": [
@@ -10280,7 +10280,7 @@
                 "type": "null"
               }
             ],
-            "description": "内容类型; None = 服务端推断 (media_id 走文件路径解析, number 走番号模式)"
+            "description": "内容类型; 未给出时: 仅 media_id 按文件路径推断, 有 number 时按番号推断"
           },
           "use_cache": {
             "items": {

--- a/web/src/client/schemas.gen.ts
+++ b/web/src/client/schemas.gen.ts
@@ -5298,8 +5298,7 @@ export const ScrapeSubmissionSchema = {
                     type: 'null'
                 }
             ],
-            title: 'Number',
-            description: '番号 (如 MIDV-123). 可与 media_id 同时提交: 此时用此字段刮削并关联该文件'
+            title: 'Number'
         },
         media_id: {
             anyOf: [
@@ -5311,7 +5310,7 @@ export const ScrapeSubmissionSchema = {
                 }
             ],
             title: 'Media Id',
-            description: 'MediaFile ID. 单独提交时从文件路径解析番号; 与 number 同时提交时只负责关联文件'
+            description: 'MediaFile ID. 通常仅用于内部提交任务，手动提交无需指定'
         },
         content_type: {
             anyOf: [

--- a/web/src/client/schemas.gen.ts
+++ b/web/src/client/schemas.gen.ts
@@ -5299,7 +5299,7 @@ export const ScrapeSubmissionSchema = {
                 }
             ],
             title: 'Number',
-            description: '番号 (如 MIDV-123); 与 media_id 互斥'
+            description: '番号 (如 MIDV-123). 可与 media_id 同时提交: 此时用此字段刮削并关联该文件'
         },
         media_id: {
             anyOf: [
@@ -5311,7 +5311,7 @@ export const ScrapeSubmissionSchema = {
                 }
             ],
             title: 'Media Id',
-            description: 'MediaFile ID; 服务端从中读取 number, 与 number 互斥'
+            description: 'MediaFile ID. 单独提交时从文件路径解析番号; 与 number 同时提交时只负责关联文件'
         },
         content_type: {
             anyOf: [
@@ -5322,7 +5322,7 @@ export const ScrapeSubmissionSchema = {
                     type: 'null'
                 }
             ],
-            description: '内容类型; None = 服务端推断 (media_id 走文件路径解析, number 走番号模式)'
+            description: '内容类型; 未给出时: 仅 media_id 按文件路径推断, 有 number 时按番号推断'
         },
         use_cache: {
             items: {

--- a/web/src/client/types.gen.ts
+++ b/web/src/client/types.gen.ts
@@ -2665,17 +2665,17 @@ export type ScrapeSubmission = {
     /**
      * Number
      *
-     * 番号 (如 MIDV-123); 与 media_id 互斥
+     * 番号 (如 MIDV-123). 可与 media_id 同时提交: 此时用此字段刮削并关联该文件
      */
     number?: string | null;
     /**
      * Media Id
      *
-     * MediaFile ID; 服务端从中读取 number, 与 number 互斥
+     * MediaFile ID. 单独提交时从文件路径解析番号; 与 number 同时提交时只负责关联文件
      */
     media_id?: number | null;
     /**
-     * 内容类型; None = 服务端推断 (media_id 走文件路径解析, number 走番号模式)
+     * 内容类型; 未给出时: 仅 media_id 按文件路径推断, 有 number 时按番号推断
      */
     content_type?: ContentType | null;
     /**

--- a/web/src/client/types.gen.ts
+++ b/web/src/client/types.gen.ts
@@ -2664,14 +2664,12 @@ export type ScheduleUpdateRequest = {
 export type ScrapeSubmission = {
     /**
      * Number
-     *
-     * 番号 (如 MIDV-123). 可与 media_id 同时提交: 此时用此字段刮削并关联该文件
      */
     number?: string | null;
     /**
      * Media Id
      *
-     * MediaFile ID. 单独提交时从文件路径解析番号; 与 number 同时提交时只负责关联文件
+     * MediaFile ID. 通常仅用于内部提交任务，手动提交无需指定
      */
     media_id?: number | null;
     /**

--- a/web/src/components/library/library-media-table.tsx
+++ b/web/src/components/library/library-media-table.tsx
@@ -1,6 +1,6 @@
 import { ActionIcon, Badge, Button, Checkbox, Group, Stack, Table, Text } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
-import { IconRefresh, IconTrash } from "@tabler/icons-react";
+import { IconForms, IconRefresh, IconTrash } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { type ReactNode, useState } from "react";
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { listMediaQueryKey } from "@/client/@tanstack/react-query.gen";
 import { deleteMedia, submitTask } from "@/client/sdk.gen";
 import type {
+  ContentType,
   MediaFileResponse,
   MediaFileStatus,
   MediaSortField,
@@ -17,6 +18,7 @@ import { FilePhaseBadges } from "@/components/media/file-phase-badges";
 import { ListToolbar } from "@/components/common/list-toolbar";
 import { SortableTh } from "@/components/common/sortable-th";
 import { SelectionBar } from "@/components/common/selection-bar";
+import { ScrapeOverrideDialog } from "./scrape-override-dialog";
 import { useIdSelection } from "@/hooks/use-id-selection";
 import { extractErrorMessage } from "@/lib/api-error";
 import { confirm } from "@/lib/confirm";
@@ -103,6 +105,8 @@ export function LibraryMediaTable({
   const { selected, selectedIds, toggleOne, toggleAll, isAllSelected, clear } = useIdSelection();
   const [batchScraping, setBatchScraping] = useState(false);
   const [batchDeleting, setBatchDeleting] = useState(false);
+  const [overrideTarget, setOverrideTarget] = useState<MediaFileResponse | null>(null);
+  const [overrideSaving, setOverrideSaving] = useState(false);
 
   const invalidate = () => void queryClient.invalidateQueries({ queryKey: listMediaQueryKey() });
 
@@ -154,6 +158,34 @@ export function LibraryMediaTable({
     }
     clear();
     invalidate();
+  }
+
+  async function handleOverrideScrape(number: string, contentType: ContentType | undefined) {
+    if (overrideTarget == null) return;
+    setOverrideSaving(true);
+    try {
+      await submitTask({
+        body: {
+          type: "scrape",
+          media_id: overrideTarget.id,
+          number,
+          ...(contentType != null ? { content_type: contentType } : {}),
+        },
+        throwOnError: true,
+      });
+      notifications.show({
+        message: t("common:toast.scrapeStarted"),
+        color: "blue",
+      });
+      setOverrideTarget(null);
+    } catch (err) {
+      notifications.show({
+        message: extractErrorMessage(err, t("common:toast.operationFailed")),
+        color: "red",
+      });
+    } finally {
+      setOverrideSaving(false);
+    }
   }
 
   async function handleDeleteOne(mediaId: number) {
@@ -237,7 +269,7 @@ export function LibraryMediaTable({
                 w={COLUMN_WIDTH[field]}
               />
             ))}
-            <Table.Th w={88} ta="right">
+            <Table.Th w={120} ta="right">
               {t("columns.actions")}
             </Table.Th>
           </Table.Tr>
@@ -318,6 +350,13 @@ export function LibraryMediaTable({
                     </ActionIcon>
                     <ActionIcon
                       variant="subtle"
+                      onClick={() => setOverrideTarget(item)}
+                      title={t("actions.scrapeWithNumber")}
+                    >
+                      <IconForms size={16} />
+                    </ActionIcon>
+                    <ActionIcon
+                      variant="subtle"
                       color="red"
                       onClick={() => void handleDeleteOne(item.id)}
                       title={t("common:actions.delete")}
@@ -337,6 +376,14 @@ export function LibraryMediaTable({
           {t("empty")}
         </Text>
       )}
+      <ScrapeOverrideDialog
+        target={overrideTarget}
+        saving={overrideSaving}
+        onClose={() => {
+          if (!overrideSaving) setOverrideTarget(null);
+        }}
+        onSubmit={(number, contentType) => void handleOverrideScrape(number, contentType)}
+      />
     </ListToolbar>
   );
 }

--- a/web/src/components/library/scrape-override-dialog.tsx
+++ b/web/src/components/library/scrape-override-dialog.tsx
@@ -1,0 +1,97 @@
+import { Button, Group, Input, Modal, Stack, TextInput } from "@mantine/core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { ContentType, MediaFileResponse } from "@/client/types.gen";
+import { EnumToggle } from "@/components/common/enum-toggle";
+import { CONTENT_TYPES } from "@/lib/exhaustive-maps";
+
+const CONTENT_TYPE_OPTIONS = ["", ...CONTENT_TYPES] as const;
+
+type ContentTypeChoice = (typeof CONTENT_TYPE_OPTIONS)[number];
+
+interface ScrapeOverrideDialogProps {
+  target: MediaFileResponse | null;
+  saving: boolean;
+  onClose: () => void;
+  onSubmit: (number: string, contentType: ContentType | undefined) => void;
+}
+
+export function ScrapeOverrideDialog({
+  target,
+  saving,
+  onClose,
+  onSubmit,
+}: ScrapeOverrideDialogProps) {
+  const { t } = useTranslation(["library", "common"]);
+
+  return (
+    <Modal opened={target != null} onClose={onClose} title={t("scrapeOverride.title")} size="lg">
+      {target != null && (
+        <ScrapeOverrideForm
+          key={target.id}
+          initialNumber={target.number ?? ""}
+          saving={saving}
+          onClose={onClose}
+          onSubmit={onSubmit}
+        />
+      )}
+    </Modal>
+  );
+}
+
+function ScrapeOverrideForm({
+  initialNumber,
+  saving,
+  onClose,
+  onSubmit,
+}: {
+  initialNumber: string;
+  saving: boolean;
+  onClose: () => void;
+  onSubmit: (number: string, contentType: ContentType | undefined) => void;
+}) {
+  const { t } = useTranslation(["library", "common"]);
+  const [number, setNumber] = useState(initialNumber);
+  const [contentType, setContentType] = useState<ContentTypeChoice>("");
+  const trimmed = number.trim();
+
+  return (
+    <Stack>
+      <TextInput
+        label={t("scrapeOverride.number")}
+        placeholder={t("scrapeOverride.numberPlaceholder")}
+        value={number}
+        onChange={(event) => setNumber(event.currentTarget.value)}
+        data-autofocus
+      />
+      <Input.Wrapper
+        label={t("scrapeOverride.contentType")}
+        description={t("scrapeOverride.contentTypeHint")}
+      >
+        <EnumToggle
+          fullWidth
+          options={CONTENT_TYPE_OPTIONS}
+          value={contentType}
+          onChange={setContentType}
+          getLabel={(value) =>
+            value === ""
+              ? t("scrapeOverride.contentTypeAuto")
+              : t(`scrapeOverride.contentTypes.${value}`)
+          }
+        />
+      </Input.Wrapper>
+      <Group justify="flex-end">
+        <Button variant="default" onClick={onClose} disabled={saving}>
+          {t("common:actions.cancel")}
+        </Button>
+        <Button
+          loading={saving}
+          disabled={trimmed === ""}
+          onClick={() => onSubmit(trimmed, contentType === "" ? undefined : contentType)}
+        >
+          {t("scrapeOverride.submit")}
+        </Button>
+      </Group>
+    </Stack>
+  );
+}

--- a/web/src/i18n/locales/en/library.json
+++ b/web/src/i18n/locales/en/library.json
@@ -54,7 +54,7 @@
     "number": "Number",
     "numberPlaceholder": "e.g. MIDV-123",
     "contentType": "Content type",
-    "contentTypeHint": "Leave empty to infer from the number you enter. A chosen value is used as-is.",
+    "contentTypeHint": "Leave empty to infer from the number you enter.",
     "contentTypeAuto": "Infer automatically",
     "submit": "Start scrape",
     "contentTypes": {

--- a/web/src/i18n/locales/en/library.json
+++ b/web/src/i18n/locales/en/library.json
@@ -46,7 +46,26 @@
   },
   "actions": {
     "scrape": "Scrape",
+    "scrapeWithNumber": "Scrape with number",
     "batchScrape": "Batch Scrape"
+  },
+  "scrapeOverride": {
+    "title": "Scrape with number",
+    "number": "Number",
+    "numberPlaceholder": "e.g. MIDV-123",
+    "contentType": "Content type",
+    "contentTypeHint": "Leave empty to infer from the number you enter. A chosen value is used as-is.",
+    "contentTypeAuto": "Infer automatically",
+    "submit": "Start scrape",
+    "contentTypes": {
+      "censored": "Censored",
+      "uncensored": "Uncensored",
+      "chinese": "Chinese",
+      "western": "Western",
+      "fc2": "FC2",
+      "amateur": "Amateur",
+      "hentai": "Hentai"
+    }
   },
   "batch": {
     "confirmDeleteTitle": "Delete Media Files",

--- a/web/src/i18n/locales/en/tasks.json
+++ b/web/src/i18n/locales/en/tasks.json
@@ -218,11 +218,11 @@
     "scrape": {
       "number": {
         "label": "Number",
-        "description": "Content ID (e.g., MIDV-123); mutually exclusive with Media ID."
+        "description": "Content ID (e.g., MIDV-123). May be sent alone, or together with Media ID: both fields scrape this number and attach the file."
       },
       "media_id": {
         "label": "Media ID",
-        "description": "MediaFile ID; server reads the number from it. Mutually exclusive with Number."
+        "description": "MediaFile ID. Alone, the server parses the number from the file path; together with Number, this field only attaches the file."
       },
       "content_type": {
         "label": "Content Type",

--- a/web/src/i18n/locales/en/tasks.json
+++ b/web/src/i18n/locales/en/tasks.json
@@ -217,12 +217,11 @@
     },
     "scrape": {
       "number": {
-        "label": "Number",
-        "description": "Content ID (e.g., MIDV-123). May be sent alone, or together with Media ID: both fields scrape this number and attach the file."
+        "label": "Number"
       },
       "media_id": {
         "label": "Media ID",
-        "description": "MediaFile ID. Alone, the server parses the number from the file path; together with Number, this field only attaches the file."
+        "description": "MediaFile ID. Usually only for internal task submission; not needed when submitting by hand."
       },
       "content_type": {
         "label": "Content Type",

--- a/web/src/i18n/locales/zh-CN/library.json
+++ b/web/src/i18n/locales/zh-CN/library.json
@@ -52,7 +52,7 @@
     "number": "番号",
     "numberPlaceholder": "例如 MIDV-123",
     "contentType": "内容类型",
-    "contentTypeHint": "留空则根据填写的番号推断。指定后按所选类型刮削。",
+    "contentTypeHint": "留空则根据填写的番号推断",
     "contentTypeAuto": "自动推断",
     "submit": "开始刮削",
     "contentTypes": {

--- a/web/src/i18n/locales/zh-CN/library.json
+++ b/web/src/i18n/locales/zh-CN/library.json
@@ -44,7 +44,26 @@
   },
   "actions": {
     "scrape": "刮削",
+    "scrapeWithNumber": "指定番号刮削",
     "batchScrape": "批量刮削"
+  },
+  "scrapeOverride": {
+    "title": "指定番号刮削",
+    "number": "番号",
+    "numberPlaceholder": "例如 MIDV-123",
+    "contentType": "内容类型",
+    "contentTypeHint": "留空则根据填写的番号推断。指定后按所选类型刮削。",
+    "contentTypeAuto": "自动推断",
+    "submit": "开始刮削",
+    "contentTypes": {
+      "censored": "有码",
+      "uncensored": "无码",
+      "chinese": "国产",
+      "western": "欧美",
+      "fc2": "FC2",
+      "amateur": "素人",
+      "hentai": "动漫"
+    }
   },
   "batch": {
     "confirmDeleteTitle": "删除媒体文件",

--- a/web/src/i18n/locales/zh-CN/tasks.json
+++ b/web/src/i18n/locales/zh-CN/tasks.json
@@ -214,12 +214,11 @@
     },
     "scrape": {
       "number": {
-        "label": "番号",
-        "description": "内容编号（如 MIDV-123）。可只填此项，也可与 Media ID 同时填写：同时填写时用此番号刮削并关联该文件。"
+        "label": "番号"
       },
       "media_id": {
         "label": "Media ID",
-        "description": "MediaFile ID。只填此项时从文件路径解析番号；与番号同时填写时只负责关联文件。"
+        "description": "MediaFile ID. 通常仅用于内部提交任务，手动提交无需指定"
       },
       "content_type": {
         "label": "内容类型",

--- a/web/src/i18n/locales/zh-CN/tasks.json
+++ b/web/src/i18n/locales/zh-CN/tasks.json
@@ -215,11 +215,11 @@
     "scrape": {
       "number": {
         "label": "番号",
-        "description": "内容编号（如 MIDV-123）；与 Media ID 互斥。"
+        "description": "内容编号（如 MIDV-123）。可只填此项，也可与 Media ID 同时填写：同时填写时用此番号刮削并关联该文件。"
       },
       "media_id": {
         "label": "Media ID",
-        "description": "MediaFile ID；服务端从中读取番号。与 Number 互斥。"
+        "description": "MediaFile ID。只填此项时从文件路径解析番号；与番号同时填写时只负责关联文件。"
       },
       "content_type": {
         "label": "内容类型",


### PR DESCRIPTION
## Summary
- 刮削任务可以同时提交番号与媒体文件: 用填写的番号刮削, 并挂到该文件. 空白番号视为未填写, 仍按文件路径解析.
- 媒体库文件表每一行增加「指定番号刮削」对话框 (番号必填, 内容类型可选). 原有刷新图标与批量刮削仍只带媒体文件 ID.
- 任务页「提交任务」表单的互斥说明已改为允许两项同时填写.

## Test plan
- [x] `tests/api/test_tasks.py`: 同时提交、显式内容类型、空白番号回退、缺失文件 404
- [ ] 在 `/libraries/{id}` 文件表打开「指定番号刮削」, 填写番号后确认任务参数含该番号与 `media_file_id`
- [ ] 行上原有刷新图标仍只提交媒体文件 ID
- [ ] `/tasks` 提交刮削时可同时填写番号与 Media ID
- [ ] CI 全量通过

Close #70