### PR TITLE
fix: Windows 超分按官方包 .exe 定位可执行文件

### DIFF
--- a/src/amane/sr/binary.py
+++ b/src/amane/sr/binary.py
@@ -28,7 +28,11 @@ def get_tool_dir(data_dir: Path) -> Path:
 def get_binary_path(tool: SrTool, data_dir: Path) -> Path:
     """返回指定工具的二进制存储路径."""
     meta = get_tool_meta(tool)
-    return get_tool_dir(data_dir) / tool / meta.binary_name
+    name = meta.binary_name
+    # Windows 官方包是 .exe; CreateProcess 在路径含目录时不会补后缀.
+    if sys.platform == "win32":
+        name = f"{name}.exe"
+    return get_tool_dir(data_dir) / tool / name
 
 
 def is_binary_available(tool: SrTool, data_dir: Path) -> bool:
@@ -36,8 +40,7 @@ def is_binary_available(tool: SrTool, data_dir: Path) -> bool:
     binary_path = get_binary_path(tool, data_dir)
     if not binary_path.is_file():
         return False
-    # Windows 无 POSIX 执行位; os.access 的可执行判断对非 .exe/.bat 等宿主类型不适用,
-    # 文件已存在即视作就绪 (binary_name 也刻意不含平台扩展名).
+    # Windows 无 POSIX 执行位; 文件存在即视作就绪.
     if sys.platform == "win32":
         return True
     return os.access(binary_path, os.X_OK)


### PR DESCRIPTION
## Summary

- Windows 官方超分包内的可执行文件带 `.exe`. `get_binary_path` 只拼无后缀路径, `CreateProcess` 在路径含目录时不会补后缀, 目录里已有文件仍报二进制不存在.

## Test plan

- [ ] Windows 上触发一次超分 (默认 `waifu-photo-2x` 或 `realesr-photo-4x`), 应定位到 `{data_dir}/tools/{tool}/*.exe` 并启动
- [ ] 已解压过官方 zip 的目录不必重新下载

Fix #98