### PR TITLE
feat: 详情与对比来源展示出演者性别

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -15,7 +15,7 @@
 
 片库 / 演员 / 分类无独立「管理」路由: `view=grid|list` (分类 `cloud|list`). grid/cloud 只读; list 才有多选与破坏性操作. Feed 相反: 阅读器 (`/feeds`) 与源表 (`/feeds/sources`) 不共用布局, 选中源不在阅读器顶栏展开操作条. 侧栏点条目只筛选阅读器; 源/分组的左侧图标深链源表 (不修改当前选中), 源经由 `?feed=` (按当前筛排定位到该行所在页并高亮, `feed` 不是筛选条件, 修改搜索框会清除该参数), 分组经由 `?q=`. 「全部」与「未分组」没有这条入口. 侧栏 `NavLink` 用 TanStack `Link` 时, Mantine 把 `aria-current=page` 画成选中, 而 Link 默认把子路径也标成当前页; `/feeds` 必须 `activeOptions.exact` 且忽略 search, 否则打开 `/feeds/sources` 时「订阅」也会亮.
 
-**入口分流**: 非演员实体 → `/catalog/$kind/$facetId`; 演员 → `/actors/$actorId`. 结果筛选在 `/meta` (`q` + 各 `*_id`; `saved_query_id` 与其它筛选项 AND, 见 [agent.md](agent.md)). `FacetBadge` 默认 `mode="catalog"` (actor 深链 `/actors/$id`), 筛选深链用 `mode="meta"`. 演员不进入 `/catalog`.
+**入口分流**: 非演员实体 → `/catalog/$kind/$facetId`; 演员 → `/actors/$actorId`. 结果筛选在 `/meta` (`q` + 各 `*_id`; `saved_query_id` 与其它筛选项 AND, 见 [agent.md](agent.md)). `FacetBadge` 默认 `mode="catalog"` (actor 深链 `/actors/$id`), 筛选深链用 `mode="meta"`. 演员不进入 `/catalog`. 详情出演徽章的性别来自同一次 `Actor` 行查找 (`actor_genders`), 不是 `raw` 里的 `FilmActor`; 仅 `female` / `male` 画符号.
 
 分类实体页必须是 `catalog.$kind_.$facetId.tsx` (trailing `_`): `$kind` 是词云叶页而非 layout, 写成 `catalog.$kind.$facetId` 会成为无 `<outlet />` 的父路由的子路由, 子页永不渲染.
 

--- a/src/amane/api/models/metadata.py
+++ b/src/amane/api/models/metadata.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import BaseModel, Field, model_validator
 
 from ...db import Metadata
+from ...enums import ActorGender
 from ...handlers import CacheKind
 from ...parsing import ContentType, Mosaic
 from ...utils.model import anyof_extras, create_partial_model, kv
@@ -84,6 +85,7 @@ class MetadataDetailResponse(BaseModel):
     user_tags: list[UserTagResponse] = []
     comments: list[CommentResponse] = []
     actor_ids: dict[str, int] = {}
+    actor_genders: dict[str, ActorGender] = {}
     director_ids: dict[str, int] = {}
     tag_ids: dict[str, int] = {}
     studio_id: int | None = None

--- a/src/amane/api/routes/metadata.py
+++ b/src/amane/api/routes/metadata.py
@@ -190,9 +190,15 @@ async def get_metadata(metadata_id: int, repo: RepoDep) -> MetadataDetailRespons
     files = await repo.get_media_by_metadata_id(metadata_id)
     user_tags = await repo.list_metadata_user_tags(metadata_id)
     comments = await repo.list_comments(metadata_id)
-    actor_ids, director_ids, tag_ids, studio_id, publisher_id, series_id = await repo.resolve_metadata_facet_ids(
-        metadata
-    )
+    (
+        actor_ids,
+        actor_genders,
+        director_ids,
+        tag_ids,
+        studio_id,
+        publisher_id,
+        series_id,
+    ) = await repo.resolve_metadata_facet_ids(metadata)
     return MetadataDetailResponse(
         metadata=to_resp(MetadataResponse, metadata).model_copy(
             update={
@@ -204,6 +210,7 @@ async def get_metadata(metadata_id: int, repo: RepoDep) -> MetadataDetailRespons
         user_tags=[to_resp(UserTagResponse, t) for t in user_tags],
         comments=[to_resp(CommentResponse, c) for c in comments],
         actor_ids=actor_ids,
+        actor_genders=actor_genders,
         director_ids=director_ids,
         tag_ids=tag_ids,
         studio_id=studio_id,

--- a/src/amane/db/repos/facets.py
+++ b/src/amane/db/repos/facets.py
@@ -4,6 +4,7 @@ from typing import Unpack
 from sqlalchemy import asc
 from sqlalchemy import delete as sqla_delete
 from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from ...enums import ActorGender
 from ..actor_lookup import build_actor_lookup_names, list_actor_aliases, lookup_actors_by_name
@@ -54,6 +55,16 @@ from .facet_helpers import (
 )
 
 
+async def _rows_by_names[T: Actor | Director | Tag | Studio | Publisher | Series](
+    session: AsyncSession, model: type[T], names: Sequence[str]
+) -> list[T]:
+    """按 UNIQUE 展示名批量取回; 空名单不发 ``IN ()``."""
+    unique = list(dict.fromkeys(n for n in names if n))
+    if not unique:
+        return []
+    return list((await session.exec(select(model).where(col(model.name).in_(unique)))).all())
+
+
 class FacetsRepoMixin(RepositoryMixinBase):
     async def resolve_metadata_facet_ids(
         self, meta: Metadata
@@ -70,37 +81,32 @@ class FacetsRepoMixin(RepositoryMixinBase):
         async with self._session() as session:
             actor_ids: dict[str, int] = {}
             actor_genders: dict[str, ActorGender] = {}
-            for name in normalize_names(meta.actors):
-                row = (await session.exec(select(Actor).where(Actor.name == name))).first()
-                if row is not None and row.id is not None:
-                    actor_ids[name] = row.id
-                    actor_genders[name] = row.gender
-            director_ids: dict[str, int] = {}
-            for name in normalize_names(meta.directors):
-                row = (await session.exec(select(Director).where(Director.name == name))).first()
-                if row is not None and row.id is not None:
-                    director_ids[name] = row.id
-            tag_ids: dict[str, int] = {}
-            for name in normalize_names(meta.tags):
-                row = (await session.exec(select(Tag).where(Tag.name == name))).first()
-                if row is not None and row.id is not None:
-                    tag_ids[name] = row.id
-            studio_id: int | None = None
-            if meta.studio:
-                row = (await session.exec(select(Studio).where(Studio.name == meta.studio))).first()
-                if row is not None:
-                    studio_id = row.id
-            publisher_id: int | None = None
-            if meta.publisher:
-                row = (await session.exec(select(Publisher).where(Publisher.name == meta.publisher))).first()
-                if row is not None:
-                    publisher_id = row.id
-            series_id: int | None = None
-            if meta.series:
-                row = (await session.exec(select(Series).where(Series.name == meta.series))).first()
-                if row is not None:
-                    series_id = row.id
-            return actor_ids, actor_genders, director_ids, tag_ids, studio_id, publisher_id, series_id
+            for row in await _rows_by_names(session, Actor, normalize_names(meta.actors)):
+                if row.id is not None:
+                    actor_ids[row.name] = row.id
+                    actor_genders[row.name] = row.gender
+            director_ids = {
+                row.name: row.id
+                for row in await _rows_by_names(session, Director, normalize_names(meta.directors))
+                if row.id is not None
+            }
+            tag_ids = {
+                row.name: row.id
+                for row in await _rows_by_names(session, Tag, normalize_names(meta.tags))
+                if row.id is not None
+            }
+            studio = (await _rows_by_names(session, Studio, [meta.studio] if meta.studio else []))[:1]
+            publisher = (await _rows_by_names(session, Publisher, [meta.publisher] if meta.publisher else []))[:1]
+            series = (await _rows_by_names(session, Series, [meta.series] if meta.series else []))[:1]
+            return (
+                actor_ids,
+                actor_genders,
+                director_ids,
+                tag_ids,
+                studio[0].id if studio else None,
+                publisher[0].id if publisher else None,
+                series[0].id if series else None,
+            )
 
     async def list_facets(
         self,

--- a/src/amane/db/repos/facets.py
+++ b/src/amane/db/repos/facets.py
@@ -5,6 +5,7 @@ from sqlalchemy import asc
 from sqlalchemy import delete as sqla_delete
 from sqlmodel import col, select
 
+from ...enums import ActorGender
 from ..actor_lookup import build_actor_lookup_names, list_actor_aliases, lookup_actors_by_name
 from ..actor_person import actor_to_aggregated, apply_aggregated_to_actor
 from ..models import (
@@ -56,14 +57,24 @@ from .facet_helpers import (
 class FacetsRepoMixin(RepositoryMixinBase):
     async def resolve_metadata_facet_ids(
         self, meta: Metadata
-    ) -> tuple[dict[str, int], dict[str, int], dict[str, int], int | None, int | None, int | None]:
-        """名称 → 分类实体 id; 未投影的名称不出现."""
+    ) -> tuple[
+        dict[str, int],
+        dict[str, ActorGender],
+        dict[str, int],
+        dict[str, int],
+        int | None,
+        int | None,
+        int | None,
+    ]:
+        """名称 → 分类实体 id; 演员额外带已装入行上的 gender. 未投影的名称不出现."""
         async with self._session() as session:
             actor_ids: dict[str, int] = {}
+            actor_genders: dict[str, ActorGender] = {}
             for name in normalize_names(meta.actors):
                 row = (await session.exec(select(Actor).where(Actor.name == name))).first()
                 if row is not None and row.id is not None:
                     actor_ids[name] = row.id
+                    actor_genders[name] = row.gender
             director_ids: dict[str, int] = {}
             for name in normalize_names(meta.directors):
                 row = (await session.exec(select(Director).where(Director.name == name))).first()
@@ -89,7 +100,7 @@ class FacetsRepoMixin(RepositoryMixinBase):
                 row = (await session.exec(select(Series).where(Series.name == meta.series))).first()
                 if row is not None:
                     series_id = row.id
-            return actor_ids, director_ids, tag_ids, studio_id, publisher_id, series_id
+            return actor_ids, actor_genders, director_ids, tag_ids, studio_id, publisher_id, series_id
 
     async def list_facets(
         self,

--- a/tests/api/test_metadata.py
+++ b/tests/api/test_metadata.py
@@ -7,6 +7,7 @@ import pytest_asyncio
 from PIL import Image
 
 from amane.db.models import MediaFileStatus
+from amane.enums import ActorGender
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -33,7 +34,12 @@ class TestMetadataHttp:
         assert empty.json()["total"] == 0
         assert (await client.get("metadata?definition=bogus")).status_code == 422
 
-        meta = await repo.upsert_metadata(number="ABC-001", title="Test")
+        meta = await repo.upsert_metadata(
+            number="ABC-001",
+            title="Test",
+            actors=["Mei", "MaleA"],
+            actor_genders={"Mei": ActorGender.FEMALE},
+        )
         assert meta.id is not None
         media = await repo.create_media_file(library_id=1, path="/video/MIDV-001-C.mp4", number="ABC-001")
         assert media.id is not None
@@ -47,8 +53,11 @@ class TestMetadataHttp:
 
         detail = await client.get(f"metadata/{meta.id}")
         assert detail.status_code == 200
-        assert detail.json()["metadata"]["title"] == "Test"
-        assert len(detail.json()["files"]) == 1
+        body = detail.json()
+        assert body["metadata"]["title"] == "Test"
+        assert len(body["files"]) == 1
+        assert body["actor_genders"] == {"Mei": "female", "MaleA": "unknown"}
+        assert set(body["actor_ids"]) == {"Mei", "MaleA"}
         assert (await client.get("metadata/9999")).status_code == 404
 
         ok = await client.patch(f"metadata/{meta.id}", json={"release": "2020-01-15T00:00:00Z"})

--- a/tests/db/test_facets.py
+++ b/tests/db/test_facets.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import IntegrityError
 
 from amane.db.actor_lookup import build_actor_lookup_names
 from amane.db.models import Actor, FacetKind, FacetRuleAction, FacetSortField, Metadata, MetadataActor, SortOrder
+from amane.enums import ActorGender
 
 if TYPE_CHECKING:
     from amane.db.repository import Repository
@@ -49,6 +50,42 @@ class TestFacetSync:
         assert actors[0].count == 0
         items, n = await repo.list_metadata(actor_ids=[actors[0].id])
         assert n == 0 and items == []
+
+    async def test_resolve_facet_ids_skips_missing_and_empty(self, repo: Repository) -> None:
+        meta = await repo.upsert_metadata(
+            number="ABC-009",
+            actors=["Alice"],
+            directors=["DirA"],
+            tags=["tag1"],
+            studio="StudioX",
+            actor_genders={"Alice": ActorGender.FEMALE},
+        )
+        (
+            actor_ids,
+            actor_genders,
+            director_ids,
+            tag_ids,
+            studio_id,
+            publisher_id,
+            series_id,
+        ) = await repo.resolve_metadata_facet_ids(meta)
+        assert set(actor_ids) == {"Alice"}
+        assert actor_genders == {"Alice": ActorGender.FEMALE}
+        assert set(director_ids) == {"DirA"}
+        assert set(tag_ids) == {"tag1"}
+        assert studio_id is not None
+        assert publisher_id is None and series_id is None
+
+        meta.actors = ["Alice", "Ghost"]
+        meta.directors = []
+        meta.tags = ["tag1", "missing-tag"]
+        meta.studio = None
+        actor_ids, actor_genders, director_ids, tag_ids, studio_id, _, _ = await repo.resolve_metadata_facet_ids(meta)
+        assert set(actor_ids) == {"Alice"}
+        assert "Ghost" not in actor_ids
+        assert director_ids == {}
+        assert set(tag_ids) == {"tag1"}
+        assert studio_id is None
 
     async def test_unknown_facet_id_returns_empty(self, repo: Repository) -> None:
         await repo.upsert_metadata(number="ABC-003", actors=["Alice"])

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -8617,6 +8617,14 @@
             "title": "Actor Ids",
             "default": {}
           },
+          "actor_genders": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ActorGender"
+            },
+            "type": "object",
+            "title": "Actor Genders",
+            "default": {}
+          },
           "director_ids": {
             "additionalProperties": {
               "type": "integer"

--- a/web/src/client/schemas.gen.ts
+++ b/web/src/client/schemas.gen.ts
@@ -3657,6 +3657,14 @@ export const MetadataDetailResponseSchema = {
             title: 'Actor Ids',
             default: {}
         },
+        actor_genders: {
+            additionalProperties: {
+                $ref: '#/components/schemas/ActorGender'
+            },
+            type: 'object',
+            title: 'Actor Genders',
+            default: {}
+        },
         director_ids: {
             additionalProperties: {
                 type: 'integer'

--- a/web/src/client/types.gen.ts
+++ b/web/src/client/types.gen.ts
@@ -1746,6 +1746,12 @@ export type MetadataDetailResponse = {
         [key: string]: number;
     };
     /**
+     * Actor Genders
+     */
+    actor_genders?: {
+        [key: string]: ActorGender;
+    };
+    /**
      * Director Ids
      */
     director_ids?: {

--- a/web/src/components/media/facet-badge.tsx
+++ b/web/src/components/media/facet-badge.tsx
@@ -1,6 +1,7 @@
 import { Badge, type MantineColor } from "@mantine/core";
 import { Link } from "@tanstack/react-router";
-import type { FacetKind } from "@/client/types.gen";
+import type { ActorGender, FacetKind } from "@/client/types.gen";
+import { GenderMark } from "@/components/media/gender-mark";
 import { metaSearchForFacet } from "@/lib/facets";
 
 const KIND_COLOR: Record<FacetKind, MantineColor> = {
@@ -18,6 +19,8 @@ interface FacetBadgeProps {
   /** Facet id - 未知 (未建立投影索引) 时为 null/undefined, 渲染为不可点击的纯文本徽章. */
   id: number | null | undefined;
   name: string;
+  /** 仅 actor: 来自 Actor 实体. unknown / 缺省不画符号. */
+  gender?: ActorGender | null;
   /** "catalog": 分类实体页 (actor → /actors/$id); "meta": 片库列表并附带该 facet 过滤. @default "catalog" */
   mode?: "meta" | "catalog";
   variant?: "filled" | "light" | "outline" | "dot" | "transparent";
@@ -29,15 +32,20 @@ export function FacetBadge({
   kind,
   id,
   name,
+  gender,
   mode = "catalog",
   variant = "light",
   size = "sm",
 }: FacetBadgeProps) {
   const color = KIND_COLOR[kind];
+  const leftSection =
+    kind === "actor" && (gender === "female" || gender === "male") ? (
+      <GenderMark gender={gender} size={12} />
+    ) : undefined;
 
   if (id == null) {
     return (
-      <Badge color={color} variant={variant} size={size}>
+      <Badge color={color} variant={variant} size={size} leftSection={leftSection}>
         {name}
       </Badge>
     );
@@ -56,6 +64,7 @@ export function FacetBadge({
             color={color}
             variant={variant}
             size={size}
+            leftSection={leftSection}
             style={{ cursor: "pointer" }}
           >
             {name}
@@ -89,6 +98,7 @@ export function FacetBadge({
         color={color}
         variant={variant}
         size={size}
+        leftSection={leftSection}
         style={{ cursor: "pointer" }}
       >
         {name}

--- a/web/src/components/media/gender-mark.tsx
+++ b/web/src/components/media/gender-mark.tsx
@@ -1,0 +1,26 @@
+import { IconGenderFemale, IconGenderMale } from "@tabler/icons-react";
+import type { ParseKeys } from "i18next";
+import { useTranslation } from "react-i18next";
+import type { ActorGender } from "@/client/types.gen";
+
+const GENDER_LABEL_KEY = {
+  female: "browse.person.gender_female",
+  male: "browse.person.gender_male",
+  unknown: "browse.person.gender_unknown",
+} as const satisfies Record<ActorGender, ParseKeys<"metadata">>;
+
+/** 已知性别用与演员墙相同的符号; unknown 不画, 避免名单上铺满灰色标记. */
+export function GenderMark({
+  gender,
+  size = 14,
+}: {
+  gender: ActorGender | null | undefined;
+  size?: number;
+}) {
+  const { t } = useTranslation("metadata");
+  if (gender !== "female" && gender !== "male") return null;
+  const Icon = gender === "female" ? IconGenderFemale : IconGenderMale;
+  const color = gender === "female" ? "var(--mantine-color-pink-5)" : "var(--mantine-color-blue-5)";
+  const label = t(GENDER_LABEL_KEY[gender]);
+  return <Icon size={size} color={color} aria-label={label} title={label} />;
+}

--- a/web/src/components/metadata/merge-dialog.tsx
+++ b/web/src/components/metadata/merge-dialog.tsx
@@ -19,9 +19,11 @@ import { useMemo, type CSSProperties, type ReactNode } from "react";
 import type { ParseKeys } from "i18next";
 import { useTranslation } from "react-i18next";
 import { mergeMetadataMutation } from "@/client/@tanstack/react-query.gen";
-import type { MetadataField, MetadataResponse } from "@/client/types.gen";
+import type { ActorGender, MetadataField, MetadataResponse } from "@/client/types.gen";
 import { FanartStrip } from "@/components/media/fanart-lightbox";
+import { GenderMark } from "@/components/media/gender-mark";
 import { useResettingState } from "@/hooks/use-resetting-state";
+import { ACTOR_GENDERS } from "@/lib/actors/browse";
 import { extractErrorMessage } from "@/lib/api-error";
 import { assertExhaustive, exhaustiveRecord, isOneOf } from "@/lib/exhaustive";
 import { isRecord } from "@/lib/utils";
@@ -76,6 +78,7 @@ const FIELD_LABEL_KEY = exhaustiveRecord<MetadataField>()({
 
 type TextField = (typeof TEXT_FIELDS)[number];
 type MediaField = (typeof MEDIA_FIELDS)[number];
+type FilmActorValue = { name: string; gender: ActorGender };
 
 function isTextField(field: string): field is TextField {
   return isOneOf(TEXT_FIELDS, field);
@@ -85,18 +88,61 @@ function isMediaField(field: string): field is MediaField {
   return isOneOf(MEDIA_FIELDS, field);
 }
 
-function formatValue(value: unknown): string {
-  if (value == null) return "—";
-  if (Array.isArray(value)) return value.map(String).join(", ");
+/** raw.actors 为 FilmActor (`name` + `gender`) 或展示名字符串; 缺省性别视为 unknown. */
+function asFilmActor(value: unknown): FilmActorValue | undefined {
+  if (typeof value === "string" && value.length > 0) {
+    return { name: value, gender: "unknown" };
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  if (!("name" in value) || typeof value.name !== "string" || value.name.length === 0) {
+    return undefined;
+  }
+  const gender =
+    "gender" in value && isOneOf(ACTOR_GENDERS, value.gender) ? value.gender : "unknown";
+  return { name: value.name, gender };
+}
+
+function formatItem(value: unknown): string {
+  const actor = asFilmActor(value);
+  if (actor) return actor.name;
+  if (value == null) return "";
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
   if (typeof value === "object") return JSON.stringify(value);
   return String(value);
 }
 
-function sameValue(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (Array.isArray(a) && Array.isArray(b)) {
-    return a.length === b.length && a.every((v, i) => v === b[i]);
+function formatValue(value: unknown): string {
+  if (value == null) return "—";
+  if (Array.isArray(value)) {
+    const parts = value.map(formatItem).filter((s) => s.length > 0);
+    return parts.length > 0 ? parts.join(", ") : "—";
   }
+  return formatItem(value) || "—";
+}
+
+function filmActorsFromRaw(value: unknown): FilmActorValue[] {
+  if (!Array.isArray(value)) {
+    const one = asFilmActor(value);
+    return one ? [one] : [];
+  }
+  const out: FilmActorValue[] = [];
+  for (const item of value) {
+    const actor = asFilmActor(item);
+    if (actor) out.push(actor);
+  }
+  return out;
+}
+
+function sameValue(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((v, i) => sameValue(v, b[i]));
+  }
+  const fa = asFilmActor(a);
+  const fb = asFilmActor(b);
+  if (fa && fb) return fa.name === fb.name && fa.gender === fb.gender;
   return false;
 }
 
@@ -329,7 +375,14 @@ export function MergeDialog({ metadata, opened, onClose, onMerged }: MergeDialog
                     <ResultTextRow
                       key={field}
                       label={fieldLabel(field)}
-                      value={formatValue(value)}
+                      value={
+                        field === "actors" ? (
+                          <ActorNamesValue actors={filmActorsFromRaw(value)} />
+                        ) : (
+                          formatValue(value)
+                        )
+                      }
+                      tooltip={formatValue(value)}
                       source={src}
                       changed={changed}
                       onRevert={() => revert(field)}
@@ -402,9 +455,15 @@ export function MergeDialog({ metadata, opened, onClose, onMerged }: MergeDialog
                                 <Text size="xs" c="dimmed" w={100} style={{ flexShrink: 0 }}>
                                   {g.sources.join(", ")}
                                 </Text>
-                                <Text size="sm" lineClamp={2} style={{ flex: 1, minWidth: 0 }}>
-                                  {formatValue(g.value)}
-                                </Text>
+                                {field === "actors" ? (
+                                  <div style={{ flex: 1, minWidth: 0 }}>
+                                    <ActorNamesValue actors={filmActorsFromRaw(g.value)} />
+                                  </div>
+                                ) : (
+                                  <Text size="sm" lineClamp={2} style={{ flex: 1, minWidth: 0 }}>
+                                    {formatValue(g.value)}
+                                  </Text>
+                                )}
                                 {active && (
                                   <Badge size="xs" color="brand">
                                     ✓
@@ -591,18 +650,21 @@ function Panel({
 function ResultTextRow({
   label,
   value,
+  tooltip,
   source,
   changed,
   onRevert,
   revertLabel,
 }: {
   label: string;
-  value: string;
+  value: ReactNode;
+  tooltip?: string;
   source: string | undefined;
   changed: boolean;
   onRevert: () => void;
   revertLabel: string;
 }) {
+  const tip = tooltip ?? (typeof value === "string" ? value : undefined);
   return (
     <Group
       gap="sm"
@@ -616,15 +678,39 @@ function ResultTextRow({
       <Text size="sm" fw={500} w={88} style={{ flexShrink: 0 }}>
         {label}
       </Text>
-      <Tooltip label={value} multiline maw={400} disabled={value.length < 40}>
-        <Text size="sm" lineClamp={2} style={{ flex: 1, minWidth: 0 }}>
-          {value}
-        </Text>
+      <Tooltip label={tip} multiline maw={400} disabled={tip == null || tip.length < 40}>
+        {typeof value === "string" ? (
+          <Text size="sm" lineClamp={2} style={{ flex: 1, minWidth: 0 }}>
+            {value}
+          </Text>
+        ) : (
+          <div style={{ flex: 1, minWidth: 0 }}>{value}</div>
+        )}
       </Tooltip>
       <Badge size="xs" variant={changed ? "filled" : "light"} style={{ flexShrink: 0 }}>
         {source ?? "—"}
       </Badge>
       {changed && <ActionRevert onClick={onRevert} label={revertLabel} />}
+    </Group>
+  );
+}
+
+function ActorNamesValue({ actors }: { actors: FilmActorValue[] }) {
+  if (actors.length === 0) {
+    return (
+      <Text size="sm" c="dimmed">
+        —
+      </Text>
+    );
+  }
+  return (
+    <Group gap={8} wrap="wrap">
+      {actors.map((actor, index) => (
+        <Group key={`${actor.name}:${actor.gender}:${index}`} gap={4} wrap="nowrap">
+          <Text size="sm">{actor.name}</Text>
+          <GenderMark gender={actor.gender} />
+        </Group>
+      ))}
     </Group>
   );
 }

--- a/web/src/routes/meta.$metadataId.tsx
+++ b/web/src/routes/meta.$metadataId.tsx
@@ -485,7 +485,13 @@ function TitleDetailPage() {
             <FieldBlock label={t("detail.fields.actors")}>
               <Group gap={6}>
                 {item.actors.map((a) => (
-                  <FacetBadge key={a} kind="actor" id={data.actor_ids?.[a]} name={a} />
+                  <FacetBadge
+                    key={a}
+                    kind="actor"
+                    id={data.actor_ids?.[a]}
+                    name={a}
+                    gender={data.actor_genders?.[a]}
+                  />
                 ))}
               </Group>
             </FieldBlock>


### PR DESCRIPTION
## Summary
- 对比来源按 `raw.actors` 的 `FilmActor` (`name` + `gender`) 展示与分组, 已知性别画出符号.
- 详情 `GET /metadata/{id}` 在现有 Actor 行查找中一并返回 `actor_genders`; 出演徽章仅对 `female` / `male` 画符号. 列表接口不改.

## Test plan
- [ ] 打开有多源出演名单的番号, 对比来源里演员显示名称与性别符号, 不再出现 `[object Object]`
- [ ] 同一详情页出演徽章对已识别性别显示符号, `unknown` 不画
- [ ] 片库列表卡片出演名单仍为展示名, 无性别字段