### PR TITLE
fix: 聚合类字段按优先级设置拼接

### DIFF
--- a/docs/dev/data-model.md
+++ b/docs/dev/data-model.md
@@ -48,14 +48,14 @@ ORGANIZE 复制到库路径的 poster / thumb 在 `watermark.enabled` 时按**�
 | 字段类型 | 存储方式 | 取舍 |
 |----------|---------|----------|
 | 标量 (`title`, `studio`, `plot`, ...) | 单值, 聚合按字段优先级选首个非空源 | 覆盖大多数场景 |
-| URL (`poster_urls`, `thumb_urls`, ...) | list, 聚合按优先级, 物化后按下载成功重排 (见 [task-system.md](task-system.md)) | 下载时顺序尝试, 某站失效不需重新刮削 |
+| 聚合类: URL (`poster_urls`, `thumb_urls`, ...) | list, 按该字段站点顺序拼接各站非空值, 物化后按下载成功重排 (见 [task-system.md](task-system.md)) | 下载时顺序尝试, 某站失效不需重新刮削 |
 | `extrafanart_urls` | `dict[site, list[url]]` 按站点分组 | 剧照集合是站点特异的, 扁平合并会丢失站点上下文 |
 | `scores` | `dict[site, score]` | 不同评分体系 (5分 vs 100分), 保留来源让前端分别展示 |
 | `raw` | `{site: {field: value}}` 原始快照 | 离线重新聚合: 修改优先级 / 翻译规则不需重爬; 也作 per-site 复用来源 (见 [task-system.md](task-system.md) 站点级复用) |
 
 ### `field_sources`
 
-`{field_name: site_name}` 仅记录**标量字段**的来源. URL / extrafanart / scores 自带来源结构, 不写入. 用途: 调试多源不一致 + 前端展示来源. 不参与业务逻辑, 重新刮削后被覆盖.
+`{field_name: site_name}` 仅记录**标量字段**的来源. 聚合类字段 (URL / extrafanart / scores) 自带来源结构, 不写入. 用途: 调试多源不一致 + 前端展示来源. 不参与业务逻辑, 重新刮削后被覆盖.
 
 `raw` 的字段名 / 类型必须与当前 `MediaMetadata` 一致 — 它会被站点级复用直接反序列化. 模型更改名称或类型时, 结果列与 raw 是两份数据, 需单独的 data migration (见 [database.md](database.md) Autogenerate 盲区).
 

--- a/docs/dev/task-system.md
+++ b/docs/dev/task-system.md
@@ -68,7 +68,7 @@ SCRAPE **没有**「缓存命中即整体跳过爬取」的快速返回 — 完�
 `aggregate` (`src/amane/aggregate/`) 不取并集全爬再挑值, 而是先把优先级配置编译成**静态抓取图** (`build_graph`), 再按波次执行 (`execute_graph`):
 
 - **建图** (`build_graph` → `compute_waves`): handler 先把 `content_routes[type]` 与稀疏 `field_priority` 编成每字段站点链 (`compile_priority`: prefer ∩ route 前置, 其余 route 保序). `content_routes` 是该类型资格真值, 不在表内的站不会被请求. 站点 + 语言唯一确定一个 `FetchNode` (`cache_key`), 节点按拓扑分层为**波次** (层内可并行). 每个字段沿优先级链回填 `covers` 与 `fallback` 边.
-- **执行** (`execute_graph`): 逐波推进, 每波只激活仍有未满足字段且尚未请求的节点, `asyncio.gather` 并发抓取. `crawlers` 映射是可用集合: 禁用插件 / 未安装第三方 / 构造失败都不在其中, 图节点直接跳过并沿 fallback 继续, 不调用 `invoke_source` (因此不会记成 unexpected). 波后 `_collect_after_wave` 扫描全部已抓取节点: 标量字段满足即短路; URL / score / extrafanart 始终累积. 前序波结果 (`partial`) 注入后续波的爬虫查询.
+- **执行** (`execute_graph`): 逐波推进, 每波只激活仍有未满足字段且尚未请求的节点, `asyncio.gather` 并发抓取. `crawlers` 映射是可用集合: 禁用插件 / 未安装第三方 / 构造失败都不在其中, 图节点直接跳过并沿 fallback 继续, 不调用 `invoke_source` (因此不会记成 unexpected). 波后只定值标量 (满足即短路); 后波 `partial` 只携带已定标量. URL / score / extrafanart 在全部请求结束后按该字段 `field_chains` 拼接, 不按返回先后排列. 某站未返回或该字段为空则跳过, 不把后面的站提到前面.
 - **多语言合并**: 若某字段需 (site, lang) 而另一字段仅需 (site, None), `compute_waves` 合并为一次带语言请求.
 
 后果: f1=[s3,s2,s1]、f2 / f3=[s1,s2,s3] 全成功时只请求 s1, s3; 若 s1 失败则沿 fallback 由 s2 接替.

--- a/docs/dev/task-system.md
+++ b/docs/dev/task-system.md
@@ -68,7 +68,7 @@ SCRAPE **没有**「缓存命中即整体跳过爬取」的快速返回 — 完�
 `aggregate` (`src/amane/aggregate/`) 不取并集全爬再挑值, 而是先把优先级配置编译成**静态抓取图** (`build_graph`), 再按波次执行 (`execute_graph`):
 
 - **建图** (`build_graph` → `compute_waves`): handler 先把 `content_routes[type]` 与稀疏 `field_priority` 编成每字段站点链 (`compile_priority`: prefer ∩ route 前置, 其余 route 保序). `content_routes` 是该类型资格真值, 不在表内的站不会被请求. 站点 + 语言唯一确定一个 `FetchNode` (`cache_key`), 节点按拓扑分层为**波次** (层内可并行). 每个字段沿优先级链回填 `covers` 与 `fallback` 边.
-- **执行** (`execute_graph`): 逐波推进, 每波只激活仍有未满足字段且尚未请求的节点, `asyncio.gather` 并发抓取. `crawlers` 映射是可用集合: 禁用插件 / 未安装第三方 / 构造失败都不在其中, 图节点直接跳过并沿 fallback 继续, 不调用 `invoke_source` (因此不会记成 unexpected). 波后只定值标量 (满足即短路); 后波 `partial` 只携带已定标量. URL / score / extrafanart 在全部请求结束后按该字段 `field_chains` 拼接, 不按返回先后排列. 某站未返回或该字段为空则跳过, 不把后面的站提到前面.
+- **执行** (`execute_graph`): 逐波推进, 每波只激活仍有未满足字段且尚未请求的节点, `asyncio.gather` 并发抓取. `crawlers` 映射是可用集合: 禁用插件 / 未安装第三方 / 构造失败都不在其中, 图节点直接跳过并沿 fallback 继续, 不调用 `invoke_source` (因此不会记成 unexpected). 波后只定值标量 (满足即短路); 后波 `partial` 只携带已定标量. 聚合类字段 (URL / score / extrafanart, 见 [data-model.md](data-model.md)) 在全部请求结束后按该字段 `field_chains` 拼接, 不按返回先后排列. 某站未返回或该字段为空则跳过, 不把后面的站提到前面.
 - **多语言合并**: 若某字段需 (site, lang) 而另一字段仅需 (site, None), `compute_waves` 合并为一次带语言请求.
 
 后果: f1=[s3,s2,s1]、f2 / f3=[s1,s2,s3] 全成功时只请求 s1, s3; 若 s1 失败则沿 fallback 由 s2 接替.
@@ -89,7 +89,7 @@ Worker 在 `handle()` 前注入 `report_progress` 回调, 经 EventBus 发 `task
 
 **契约**: `total > 0` 时前端按 `current/total` 显示百分比; 未上报则 running 态回退 indeterminate. Handler 不调用时静默忽略.
 
-**SCRAPE**: 分母 = 标量字段数 + 2 (`materialize` / `persist`). 聚合按波次上报已满足标量字段数 (URL / score / extrafanart 只累积, 不计入); message 为当波站点 `cache_key`. 抓取结束后抬到标量满分, 再执行后两步至 `done`.
+**SCRAPE**: 分母 = 标量字段数 + 2 (`materialize` / `persist`). 聚合按波次上报已满足标量字段数 (聚合类字段不计入); message 为当波站点 `cache_key`. 抓取结束后抬到标量满分, 再执行后两步至 `done`.
 
 **ORGANIZE**: 失效索引按本库 MediaFile 条数 (`prune`). 一次遍历的结果在内存中分类后分别归档 (`trash`) 与落盘 (message 为文件名). glob 进行中 `total=0`. 空目录以 1/1 `done` 结束.
 

--- a/src/amane/aggregate/engine.py
+++ b/src/amane/aggregate/engine.py
@@ -1,4 +1,4 @@
-"""字段级多源聚合: 静态抓取图 + 按波次请求 + 标量当场短路 + 收集类字段结束时按链拼接.
+"""字段级多源聚合: 静态抓取图 + 按波次请求 + 标量当场短路 + 聚合类字段结束时按链拼接.
 
 不在 crawlers 映射中的站点标成已处理空结果, 不写入 failed / sites_queried, 也不调用 invoke_source.
 """
@@ -169,7 +169,7 @@ async def execute_graph(
     state = ExecutionState(number=query.number)
     field_total = len(SCALAR_FIELDS)
 
-    # 标量满足后移除; URL / 收集字段始终保留.
+    # 标量满足后移除; 聚合类字段始终保留.
     unsatisfied: set[MetadataField] = set(ALL_FIELDS)
 
     # 禁用插件 / 未安装来源 / 构造失败不在 crawlers 中: 标成已处理空结果,
@@ -230,7 +230,7 @@ async def execute_graph(
             sites = ", ".join(n.cache_key for n in active_nodes)
             await on_progress(_scalar_progress(unsatisfied), field_total, sites)
 
-    _assemble_collected(graph, state)
+    _assemble_aggregate_fields(graph, state)
     _fill_actor_genders(state.result, state.fetched)
     return state
 
@@ -474,7 +474,7 @@ def _collect_scalars_after_wave(graph: FetchGraph, state: ExecutionState, unsati
                 break
 
 
-def _assemble_collected(graph: FetchGraph, state: ExecutionState) -> None:
+def _assemble_aggregate_fields(graph: FetchGraph, state: ExecutionState) -> None:
     """按各字段站点顺序拼接已抓结果. 空值与未返回的站跳过, 不改变相对顺序."""
     for field, dst in URL_FIELD_MAP.items():
         urls: list[str] = []

--- a/src/amane/aggregate/engine.py
+++ b/src/amane/aggregate/engine.py
@@ -1,4 +1,4 @@
-"""字段级多源聚合: 静态抓取图 + 按波次执行 + 沿 fallback 增量合并.
+"""字段级多源聚合: 静态抓取图 + 按波次请求 + 标量当场短路 + 收集类字段结束时按链拼接.
 
 不在 crawlers 映射中的站点标成已处理空结果, 不写入 failed / sites_queried, 也不调用 invoke_source.
 """
@@ -152,8 +152,6 @@ class ExecutionState:
     sites_queried: list[SourceKey] = _f(default_factory=list)
     result: AggregatedMetadata = _f(default_factory=lambda: AggregatedMetadata(number=""))
 
-    collected: set[tuple[SourceKey, MetadataField]] = _f(default_factory=set)
-
     def __post_init__(self):
         if not self.result.number:
             self.result = AggregatedMetadata(number=self.number)
@@ -166,7 +164,7 @@ async def execute_graph(
     db_cache: Mapping[SourceKey, dict] | None = None,
     on_progress: ProgressCallback | None = None,
 ) -> ExecutionState:
-    """按波次调度, 沿 fallback 边增量合并. URL / 收集类字段只累积, 不计入进度."""
+    """按波次请求; 标量沿 fallback 当场短路. URL / 评分 / 剧照在全部请求结束后按字段链拼接."""
     snapshots = db_cache or {}
     state = ExecutionState(number=query.number)
     field_total = len(SCALAR_FIELDS)
@@ -225,13 +223,14 @@ async def execute_graph(
             if data is None:
                 state.failed.append(ck)
 
-        # 沿 fallback 立即消费本波结果.
-        _collect_after_wave(graph, state, unsatisfied)
+        # 标量沿链当场定值, 供短路与后波 partial 使用.
+        _collect_scalars_after_wave(graph, state, unsatisfied)
 
         if on_progress is not None:
             sites = ", ".join(n.cache_key for n in active_nodes)
             await on_progress(_scalar_progress(unsatisfied), field_total, sites)
 
+    _assemble_collected(graph, state)
     _fill_actor_genders(state.result, state.fetched)
     return state
 
@@ -452,66 +451,60 @@ def _fill_scalar(
     result.field_sources[field] = source_key
 
 
-def _collect_after_wave(graph: FetchGraph, state: ExecutionState, unsatisfied: set[MetadataField]) -> None:
-    for field, chain in graph.field_chains.items():
-        if field in URL_FIELD_MAP:
-            for node in chain:
-                ck = node.cache_key
-                if ck not in state.fetched or (ck, field) in state.collected:
-                    continue
-                data = state.fetched[ck]
-                if data is None:
-                    continue
-                value = getattr(data, field, None)
-                if value:
-                    dst = URL_FIELD_MAP[field]
-                    urls = [value] if isinstance(value, str) else value
-                    getattr(state.result, dst).extend(v for v in urls if v)
-                    state.collected.add((ck, field))
-
-        elif field == MetadataField.EXTRAFANART:
-            for node in chain:
-                ck = node.cache_key
-                if ck not in state.fetched or (ck, field) in state.collected:
-                    continue
-                data = state.fetched[ck]
-                if data is not None and data.extrafanart:
-                    state.result.extrafanart_urls[ck] = data.extrafanart
-                    state.collected.add((ck, field))
-
-        elif field == MetadataField.SCORE:
-            for node in chain:
-                ck = node.cache_key
-                if ck not in state.fetched or (ck, field) in state.collected:
-                    continue
-                data = state.fetched[ck]
-                if data is not None and data.score is not None:
-                    state.result.scores.append(SourcedScore(site=ck, score=data.score))
-                    state.collected.add((ck, field))
-
-        elif field in SCALAR_FIELDS:
-            # 同波 fallback 立即消费.
-            if field not in unsatisfied:
+def _collect_scalars_after_wave(graph: FetchGraph, state: ExecutionState, unsatisfied: set[MetadataField]) -> None:
+    """沿字段链定值标量. 尚未请求的节点中断该字段, 不取后面已返回的站."""
+    for field in SCALAR_FIELDS:
+        if field not in unsatisfied:
+            continue
+        for node in graph.field_chains[field]:
+            ck = node.cache_key
+            if ck not in state.fetched:
+                break
+            data = state.fetched[ck]
+            if data is None:
                 continue
-            for node in chain:
-                ck = node.cache_key
-                if ck not in state.fetched:
-                    break
-                data = state.fetched[ck]
-                if data is None:
-                    continue
-                value = getattr(data, field, None)
-                if value:
-                    _fill_scalar(state.result, field, data, ck)
-                    unsatisfied.discard(field)
-                    break
-                if field not in REQUIRED_SCALAR_FIELDS:
-                    # 可选字段: 爬虫成功但值为空 → 接受空值.
-                    _fill_scalar(state.result, field, data, ck)
-                    unsatisfied.discard(field)
-                    break
+            value = getattr(data, field, None)
+            if value:
+                _fill_scalar(state.result, field, data, ck)
+                unsatisfied.discard(field)
+                break
+            if field not in REQUIRED_SCALAR_FIELDS:
+                _fill_scalar(state.result, field, data, ck)
+                unsatisfied.discard(field)
+                break
 
-    # 被动收集 external_id / source_url.
+
+def _assemble_collected(graph: FetchGraph, state: ExecutionState) -> None:
+    """按各字段站点顺序拼接已抓结果. 空值与未返回的站跳过, 不改变相对顺序."""
+    for field, dst in URL_FIELD_MAP.items():
+        urls: list[str] = []
+        for node in graph.field_chains[field]:
+            data = state.fetched.get(node.cache_key)
+            if data is None:
+                continue
+            value = getattr(data, field, None)
+            if not value:
+                continue
+            items = [value] if isinstance(value, str) else value
+            urls.extend(v for v in items if v)
+        setattr(state.result, dst, urls)
+
+    extrafanart: dict[str, list[str]] = {}
+    for node in graph.field_chains[MetadataField.EXTRAFANART]:
+        ck = node.cache_key
+        data = state.fetched.get(ck)
+        if data is not None and data.extrafanart:
+            extrafanart[ck] = data.extrafanart
+    state.result.extrafanart_urls = extrafanart
+
+    scores: list[SourcedScore] = []
+    for node in graph.field_chains[MetadataField.SCORE]:
+        ck = node.cache_key
+        data = state.fetched.get(ck)
+        if data is not None and data.score is not None:
+            scores.append(SourcedScore(site=ck, score=data.score))
+    state.result.scores = scores
+
     for ck, data in state.fetched.items():
         if data is None:
             continue

--- a/tests/aggregate/test_engine.py
+++ b/tests/aggregate/test_engine.py
@@ -1,4 +1,4 @@
-"""测试 amane.aggregate: 静态抓取图、分波请求、标量短路、收集类字段按链拼接."""
+"""测试 amane.aggregate: 静态抓取图、分波请求、标量短路、聚合类字段按链拼接."""
 
 from collections import defaultdict
 
@@ -770,7 +770,7 @@ class TestComplexScenarios:
         assert state.result.field_sources["studio"] == "dmm"
 
 
-class TestCollectedFieldOrder:
+class TestAggregateFieldOrder:
     """出演/评分把低优先级图片站拉进前波时, 列表仍按该字段站点顺序."""
 
     @pytest.mark.asyncio

--- a/tests/aggregate/test_engine.py
+++ b/tests/aggregate/test_engine.py
@@ -1,18 +1,10 @@
-"""测试 amane.aggregate - DAG 抓取图 + 增量合并.
-
-按职责分别测试:
-- compute_waves      - 波次划分 + 语言合并
-- build_graph        - 图结构正确性 (nodes / field_chains / fallback 边)
-- execute_graph      - 执行正确性 (提前终止 / fallback 传播 / 收集字段)
-- aggregate          - 端到端编排
-"""
+"""测试 amane.aggregate: 静态抓取图、分波请求、标量短路、收集类字段按链拼接."""
 
 from collections import defaultdict
 
 import pytest
 
 from amane.aggregate import (
-    ALL_FIELDS,
     SCALAR_FIELDS,
     aggregate,
     build_graph,
@@ -29,6 +21,7 @@ from amane.enums import ActorGender, Language, MetadataField, SiteName
 S1, S2, S3 = SiteName.JAVDB, SiteName.DMM, SiteName.JAVBUS
 K1, K2, K3 = str(S1), str(S2), str(S3)
 DB, DMM, BUS, OFF = SiteName.JAVDB, SiteName.DMM, SiteName.JAVBUS, SiteName.OFFICIAL
+PLUGIN = "sample.javdbapi"
 
 IQQTV = SiteName.IQQTV
 TITLE = MetadataField.TITLE
@@ -265,14 +258,6 @@ class TestBuildGraph:
         # title 不应该出现在 DB 的 covers 中 (DB 是 title 的第三优先级)
         assert MetadataField.TITLE not in w0_nodes[DB].covers
 
-    def test_all_fields_have_chains(self):
-        """ALL_FIELDS 中的每个字段都有对应的 chain."""
-        fp = defaultdict(lambda: [DB, DMM, BUS])
-        graph = build_graph(fp, {})
-        for field in ALL_FIELDS:
-            assert field in graph.field_chains, f"Missing chain for {field}"
-            assert len(graph.field_chains[field]) > 0, f"Empty chain for {field}"
-
     def test_same_site_different_langs_produce_distinct_nodes(self):
         """同站点不同语言 = 不同节点."""
         fp = defaultdict(lambda: [DB])
@@ -300,16 +285,19 @@ class TestExecuteGraph:
         fp = defaultdict(lambda: [DB, DMM, BUS], {MetadataField.TITLE: [BUS, DMM, DB]})
         graph = build_graph(fp, {})
 
-        data = MediaMetadata(number="X", title="T1", studio="S1", plot="P1", poster_urls=["http://p.jpg"])
-        crawlers = {K1: MockCrawler(data), K2: MockCrawler(data), K3: MockCrawler(data)}
+        crawlers = {
+            K1: MockCrawler(MediaMetadata(number="X", title="T_DB", studio="S_DB", poster_urls=["http://db.jpg"])),
+            K2: MockCrawler(MediaMetadata(number="X", title="T_DMM", studio="S_DMM", poster_urls=["http://dmm.jpg"])),
+            K3: MockCrawler(MediaMetadata(number="X", title="T_BUS", studio="S_BUS", poster_urls=["http://bus.jpg"])),
+        }
 
         state = await execute_graph(graph, crawlers, SearchQuery("X"))
 
-        assert state.result.title == "T1"
-        assert state.result.field_sources["title"] == "javbus"  # BUS 是第一优先级
-        assert state.result.studio == "S1"
-        assert state.result.field_sources["studio"] == "javdb"  # DB 是第一优先级 (默认)
-        assert len(state.result.poster_urls) >= 1
+        assert state.result.title == "T_BUS"
+        assert state.result.field_sources["title"] == "javbus"
+        assert state.result.studio == "S_DB"
+        assert state.result.field_sources["studio"] == "javdb"
+        assert state.result.poster_urls == ["http://db.jpg", "http://dmm.jpg", "http://bus.jpg"]
         assert len(state.failed) == 0
 
     @pytest.mark.asyncio
@@ -473,53 +461,6 @@ class TestExecuteGraph:
         # studio 是 OPTIONAL → DB 的 "S1" 被接受
         assert state.result.studio == "S1"
         assert state.result.field_sources["studio"] == "javdb"
-
-    @pytest.mark.asyncio
-    async def test_url_collection_from_all_sites(self):
-        """URL 字段从所有已执行站点收集, 去重."""
-        fp = defaultdict(lambda: [DB, DMM])
-        graph = build_graph(fp, {})
-
-        c1 = MockCrawler(result=MediaMetadata(number="X", poster_urls=["http://a.jpg"]))
-        c2 = MockCrawler(result=MediaMetadata(number="X", poster_urls=["http://b.jpg"]))
-
-        state = await execute_graph(graph, {K1: c1, K2: c2}, SearchQuery("X"))
-
-        assert "http://a.jpg" in state.result.poster_urls
-        assert "http://b.jpg" in state.result.poster_urls
-        assert len(state.result.poster_urls) == 2
-
-    @pytest.mark.asyncio
-    async def test_scores_collected_from_all_sites(self):
-        """评分从所有已执行站点收集."""
-        fp = defaultdict(lambda: [DB, DMM])
-        graph = build_graph(fp, {})
-
-        c1 = MockCrawler(result=MediaMetadata(number="X", score=85.0))
-        c2 = MockCrawler(result=MediaMetadata(number="X", score=72.0))
-
-        state = await execute_graph(graph, {K1: c1, K2: c2}, SearchQuery("X"))
-
-        assert len(state.result.scores) == 2
-        score_sites = {s.site for s in state.result.scores}
-        assert "javdb" in score_sites
-        assert "dmm" in score_sites
-
-    @pytest.mark.asyncio
-    async def test_extrafanart_grouped_by_site(self):
-        """剧照 URL 按站点分组存储."""
-        fp = defaultdict(lambda: [DB, DMM])
-        graph = build_graph(fp, {})
-
-        c1 = MockCrawler(result=MediaMetadata(number="X", extrafanart=["http://e1.jpg", "http://e2.jpg"]))
-        c2 = MockCrawler(result=MediaMetadata(number="X", extrafanart=["http://e3.jpg"]))
-
-        state = await execute_graph(graph, {K1: c1, K2: c2}, SearchQuery("X"))
-
-        assert "javdb" in state.result.extrafanart_urls
-        assert "dmm" in state.result.extrafanart_urls
-        assert len(state.result.extrafanart_urls["javdb"]) == 2
-        assert len(state.result.extrafanart_urls["dmm"]) == 1
 
     @pytest.mark.asyncio
     async def test_external_ids_and_source_urls_collected(self):
@@ -733,16 +674,14 @@ class TestComplexScenarios:
         fp = defaultdict(lambda: [DB], {MetadataField.TITLE: [DB, DMM], MetadataField.POSTER_URLS: [DMM, DB]})
         graph = build_graph(fp, {})
 
-        # javdb 返回 title 但不含 poster_url → poster_url 回退到 dmm
-        c_javdb = MockCrawler(result=MediaMetadata(number="X", title="FromJavDB", poster_urls=[]))
+        c_javdb = MockCrawler(result=MediaMetadata(number="X", title="FromJavDB", poster_urls=["http://db.jpg"]))
         c_dmm = MockCrawler(result=MediaMetadata(number="X", title="FromDMM", poster_urls=["http://dmm.jpg"]))
 
         state = await execute_graph(graph, {K1: c_javdb, K2: c_dmm}, SearchQuery("X"))
 
-        # title 来自 javdb (第一优先级), poster_url 来自 dmm (同波 fallback)
         assert state.result.title == "FromJavDB"
         assert state.result.field_sources["title"] == "javdb"
-        assert "http://dmm.jpg" in state.result.poster_urls
+        assert state.result.poster_urls == ["http://dmm.jpg", "http://db.jpg"]
 
     @pytest.mark.asyncio
     async def test_url_drives_additional_wave_when_scalar_satisfied(self):
@@ -830,18 +769,142 @@ class TestComplexScenarios:
         assert state.result.studio == "S_DMM"  # dmm 第一优先
         assert state.result.field_sources["studio"] == "dmm"
 
+
+class TestCollectedFieldOrder:
+    """出演/评分把低优先级图片站拉进前波时, 列表仍按该字段站点顺序."""
+
     @pytest.mark.asyncio
-    async def test_duplicate_url_not_collected_twice(self):
-        """同一站点的同一 URL 字段只收集一次 (去重验证)."""
-        fp = defaultdict(lambda: [DB])
+    async def test_resrape_plugin_wave0_javdb_cache_later(self):
+        """有码补刮: 插件因出演/评分在第 0 波, javdb 缓存后到.
+
+        路由 dmm → javdb → 插件. actors/score 把插件提前.
+        dmm 无数据; javdb 无海报、有封面与剧照; 插件三类都有.
+        """
+        fp = compile_priority(
+            [DMM, DB, PLUGIN],
+            {
+                MetadataField.ACTORS: [PLUGIN, DB, DMM],
+                MetadataField.SCORE: [PLUGIN, DB, DMM],
+            },
+        )
         graph = build_graph(fp, {})
 
-        c1 = MockCrawler(result=MediaMetadata(number="X", poster_urls=["http://p.jpg"]))
-        state = await execute_graph(graph, {K1: c1}, SearchQuery("X"))
+        plugin_meta = MediaMetadata.model_validate(
+            {
+                "number": "NFDM-311",
+                "title": "FromPlugin",
+                "actors": ["P1"],
+                "poster_urls": ["http://plugin/poster.jpg"],
+                "thumb_urls": ["http://plugin/thumb.jpg"],
+                "extrafanart": ["http://plugin/e1.jpg"],
+                "score": 4.1,
+            }
+        )
+        javdb_snap = MediaMetadata.model_validate(
+            {
+                "number": "NFDM-311",
+                "title": "FromJavDB",
+                "actors": ["J1"],
+                "studio": "Freedom",
+                "poster_urls": [],
+                "thumb_urls": ["http://jdbstatic/cover.jpg"],
+                "extrafanart": ["http://jdbstatic/e1.jpg"],
+                "score": 4.36,
+            }
+        ).model_dump()
 
-        # 仅一个站点 → poster_urls 应只有一项
-        assert len(state.result.poster_urls) == 1
-        assert state.result.poster_urls[0] == "http://p.jpg"
+        state = await execute_graph(
+            graph,
+            {
+                "dmm": MockCrawler(None),
+                K1: MockCrawler(MediaMetadata(number="NFDM-311", title="ShouldNotFetch")),
+                PLUGIN: MockCrawler(plugin_meta),
+            },
+            SearchQuery("NFDM-311"),
+            db_cache={"javdb": javdb_snap},
+        )
+
+        assert state.result.title == "FromJavDB"
+        assert state.result.field_sources["title"] == "javdb"
+        assert [a.name for a in state.result.actors] == ["P1"]
+        assert state.result.field_sources["actors"] == PLUGIN
+        assert state.result.poster_urls == ["http://plugin/poster.jpg"]
+        assert state.result.thumb_urls == ["http://jdbstatic/cover.jpg", "http://plugin/thumb.jpg"]
+        assert list(state.result.extrafanart_urls) == ["javdb", PLUGIN]
+        assert [s.site for s in state.result.scores] == [PLUGIN, "javdb"]
+        assert [s.score for s in state.result.scores] == [4.1, 4.36]
+
+    @pytest.mark.asyncio
+    async def test_thumb_prefer_then_route_remainder(self):
+        """封面例外名单不含 javdb 时, 编译链仍是例外 ∩ 路由 + 其余路由保序."""
+        fp = compile_priority(
+            [DMM, DB, PLUGIN],
+            {
+                MetadataField.ACTORS: [PLUGIN, DB, DMM],
+                MetadataField.THUMB_URLS: [DMM],
+            },
+        )
+        graph = build_graph(fp, {})
+
+        state = await execute_graph(
+            graph,
+            {
+                "dmm": MockCrawler(None),
+                K1: MockCrawler(
+                    MediaMetadata(
+                        number="X",
+                        title="T",
+                        thumb_urls=["http://javdb/t.jpg"],
+                        extrafanart=["http://javdb/e.jpg"],
+                    )
+                ),
+                PLUGIN: MockCrawler(
+                    MediaMetadata.model_validate(
+                        {
+                            "number": "X",
+                            "actors": ["A"],
+                            "thumb_urls": ["http://plugin/t.jpg"],
+                            "extrafanart": ["http://plugin/e.jpg"],
+                        }
+                    )
+                ),
+            },
+            SearchQuery("X"),
+        )
+
+        assert state.result.thumb_urls == ["http://javdb/t.jpg", "http://plugin/t.jpg"]
+        assert list(state.result.extrafanart_urls) == ["javdb", PLUGIN]
+
+    @pytest.mark.asyncio
+    async def test_higher_priority_empty_url_does_not_occupy_slot(self):
+        """图片链上更前的站该字段为空时, 列表从下一站有值处开始, 不留空位."""
+        fp = compile_priority([DB, DMM, PLUGIN], {MetadataField.SCORE: [PLUGIN, DB, DMM]})
+        graph = build_graph(fp, {})
+
+        state = await execute_graph(
+            graph,
+            {
+                K1: MockCrawler(
+                    MediaMetadata(number="X", title="T", poster_urls=[], thumb_urls=["http://javdb/t.jpg"], score=1.0)
+                ),
+                "dmm": MockCrawler(
+                    MediaMetadata(number="X", poster_urls=["http://dmm/p.jpg"], thumb_urls=[], score=None)
+                ),
+                PLUGIN: MockCrawler(
+                    MediaMetadata(
+                        number="X",
+                        poster_urls=["http://plugin/p.jpg"],
+                        thumb_urls=["http://plugin/t.jpg"],
+                        score=9.0,
+                    )
+                ),
+            },
+            SearchQuery("X"),
+        )
+
+        assert state.result.poster_urls == ["http://dmm/p.jpg", "http://plugin/p.jpg"]
+        assert state.result.thumb_urls == ["http://javdb/t.jpg", "http://plugin/t.jpg"]
+        assert [s.site for s in state.result.scores] == [PLUGIN, "javdb"]
 
 
 # ============================================================
@@ -968,25 +1031,6 @@ class TestProgressReporting:
 
 
 class TestFetchGraphIntegration:
-    @pytest.mark.asyncio
-    async def test_graph_then_aggregate_roundtrip(self):
-        """build_graph → execute_graph → aggregate 全链路."""
-        fp = defaultdict(lambda: [DB, DMM], {MetadataField.TITLE: [DMM, DB], MetadataField.PLOT: [DB, DMM]})
-
-        c_javdb = MockCrawler(result=MediaMetadata(number="X", title="T1", plot="P1"))
-        c_dmm = MockCrawler(result=MediaMetadata(number="X", title="T2", plot="P2"))
-
-        result = await aggregate(SearchQuery("X"), {K1: c_javdb, K2: c_dmm}, fp)
-
-        # title → dmm 第一优先级, plot → javdb 第一优先级
-        assert result.metadata.title == "T2"
-        assert result.field_sources["title"] == "dmm"
-        assert result.metadata.plot == "P1"
-        assert result.field_sources["plot"] == "javdb"
-        # 验证 raw 包含所有站点
-        assert "javdb" in result.raw
-        assert "dmm" in result.raw
-
     @pytest.mark.asyncio
     async def test_aggregate_with_cache_and_fallback(self):
         """aggregate 配合 cache: javdb 快照命中, dmm 失败 → 部分成功."""


### PR DESCRIPTION
## Summary
- 聚合类字段不再按各站返回先后写入列表, 改为在请求结束后按 `field_priority` (经 `compile_priority` 与路由编译) 拼接.
- 分波请求仍当场定值标量, 供短路与后波读取 `studio`.
- 删除只断言成员关系的用例; 补上出演优先插件、javdb 缓存后到的补刮形态.

## Test plan
- [x] `tests/aggregate/test_engine.py` (含补刮形态与同波互逆海报顺序)
- [x] CI `just ci` / `just ci-windows`