### PR TITLE
fix: Unicode NFC / NFD 路径不再重复写入 MediaFile

### DIFF
--- a/docs/dev/data-model.md
+++ b/docs/dev/data-model.md
@@ -10,7 +10,7 @@
 
 | 实体 | 角色 | 唯一键 |
 |------|------|--------|
-| `MediaFile` | 磁盘上视频文件的索引 | `path` UNIQUE |
+| `MediaFile` | 磁盘上视频文件的索引 | `path` UNIQUE (**NFC**; 目录列出的 NFD 与 NFC 是同一路径) |
 | `Metadata` | 番号级聚合元数据 | `number` UNIQUE (**大小写不敏感**; 存库保留首次写入的原始大小写) |
 | `Resource` | URL 级下载缓存 | `url` UNIQUE |
 | `Task` | 持久化任务队列 | `id` |

--- a/docs/dev/task-system.md
+++ b/docs/dev/task-system.md
@@ -49,7 +49,7 @@
 
 字段组合: `scan={"add"}, scrape=set()` → 仅注册不刮削; `scan={"add"}, scrape={"pending"}` → 注册 + 刮削; `scan={"remove"}` → 仅删除失效记录. 落盘另交 ORGANIZE.
 
-扫描遍历经由 `scan_library` (`@in_thread` glob / stat, 一次分类为跳过 / 归档 / 媒体), 与库内索引的差集在 Python 计算 (`list_media_files` 一次全部读取). 不允许将整棵树的路径放入 SQL `IN` / `NOT IN`: `NOT IN` 按批拆分会把其它批里真实存在的文件误判为失效. 仅 `remove` 时对库内记录 `exists`, 不遍历磁盘树. fan-out 必须 `list_media_files(..., limit=None)`: 默认 50 是 `GET /media` 的列表分页, 不是批量任务上限.
+扫描遍历经由 `scan_library` (`@in_thread` glob / stat, 一次分类为跳过 / 归档 / 媒体), 与库内索引的差集在 Python 计算 (`list_media_files` 一次全部读取). 不允许将整棵树的路径放入 SQL `IN` / `NOT IN`: `NOT IN` 按批拆分会把其它批里真实存在的文件误判为失效. 仅 `remove` 时对库内记录 `exists`, 不遍历磁盘树. fan-out 必须 `list_media_files(..., limit=None)`: 默认 50 是 `GET /media` 的列表分页, 不是批量任务上限. `MediaFile.path` 的写入、按路径查找、有效 / 失效集合差一律 NFC (`nfc_path`). 从库内路径打开、判断存在、落盘必须经 `existing_disk_path` (先试传入形式, 再试规范等价的 NFC / NFD). 扫描当次列出的原字符串可直接用于 I/O.
 
 文件注册 (watcher 发现与 REFRESH 扫描共用 `register_media_file`) 只写路径, 不计算 oshash. 指纹只在 SCRAPE 时按需计算: 本次实例化的爬虫 `profile().uses_file_hash` (ThePornDB) 且 `MediaFile.oshash` 为空, 才 `ensure_oshash`; 失败留 `None`, 不阻断刮削.
 
@@ -123,7 +123,7 @@ handler 之间复用的阶段逻辑, 不是一条可跳步的总管线:
 - **海报缺失**: 按 `scraping.crop_poster` 从已落盘 thumb 裁剪兜底.
 - **已就位**: 源与模板 dest 已是同一文件 (含硬链同一 inode) 时视为成功, 不追加 `(1)`; 碰撞改名只用于 dest 被另一文件占用.
 - **链接入口**: `link_template` 非空时, 视频就位后在库根之外写 strm 或软链接, 指向这次的 dest. `link_mode=strm` 时正文按 `strm_content_template` 渲染 (空则绝对路径). `MediaFile.path` 仍是真实视频. 链接写入失败时 dest 仍回写 (视频已搬家), 任务记失败以便重试补链接.
-- **失效索引**: ORGANIZE 落盘前按库删除 path 在磁盘上不存在的 MediaFile. 碰撞改名只检查磁盘; 不先删除磁盘上已不存在、仍保留在库中的 MediaFile 记录, dest(1) 会在 UNIQUE 上与库内旧 path 冲突.
+- **失效索引**: ORGANIZE 落盘前按库删除 path 在磁盘上不存在的 MediaFile (`existing_disk_path`). 碰撞改名只检查磁盘; 不先删除磁盘上已不存在、仍保留在库中的 MediaFile 记录, dest(1) 会在 UNIQUE 上与库内旧 path 冲突.
 
 ## 刮削期资源物化
 

--- a/src/amane/db/migrations/versions/c1334030b9f1_nfc_media_file_paths.py
+++ b/src/amane/db/migrations/versions/c1334030b9f1_nfc_media_file_paths.py
@@ -1,0 +1,55 @@
+"""nfc media file paths
+
+Revision ID: c1334030b9f1
+Revises: 9d6cb1706ad1
+Create Date: 2026-09-05 07:58:00.681029
+
+MediaFile.path 以 NFC 存库. 同一 NFC 路径的重复行只保留一行: 有 Metadata 优先, 其次 scraped, 再取较小 id.
+"""
+
+from collections import defaultdict
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from amane.utils.path import nfc_path
+
+# revision identifiers, used by Alembic.
+revision: str = "c1334030b9f1"
+down_revision: str | None = "9d6cb1706ad1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _keeper(group: list[tuple[int, str, int | None, str]]) -> tuple[int, str, int | None, str]:
+    def rank(row: tuple[int, str, int | None, str]) -> tuple[int, int, int]:
+        has_meta = 0 if row[2] is not None else 1
+        scraped = 0 if row[3].casefold() == "scraped" else 1
+        return (has_meta, scraped, row[0])
+
+    return min(group, key=rank)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    rows = conn.execute(sa.text("SELECT id, path, metadata_id, status FROM media_files")).fetchall()
+    groups: dict[str, list[tuple[int, str, int | None, str]]] = defaultdict(list)
+    for row in rows:
+        groups[nfc_path(str(row[1]))].append((row[0], row[1], row[2], row[3]))
+
+    for canonical, group in groups.items():
+        keep_id, keep_path, _meta, _status = _keeper(group)
+        for extra_id, _path, _meta, _status in group:
+            if extra_id == keep_id:
+                continue
+            conn.execute(sa.text("DELETE FROM media_files WHERE id = :id"), {"id": extra_id})
+        if keep_path != canonical:
+            conn.execute(
+                sa.text("UPDATE media_files SET path = :path WHERE id = :id"),
+                {"path": canonical, "id": keep_id},
+            )
+
+
+def downgrade() -> None:
+    pass

--- a/src/amane/db/models.py
+++ b/src/amane/db/models.py
@@ -147,6 +147,7 @@ class MediaFile(SQLModel, table=True):
     __tablename__ = "media_files"  # type: ignore[assignment]
 
     id: int | None = Field(default=None, primary_key=True)
+    # 库内身份为 NFC. 写入与按路径查找只经 Repository (`nfc_path`).
     path: str = Field(unique=True, nullable=False, index=True)
     oshash: str | None = None
     size: int | None = None

--- a/src/amane/db/repos/media.py
+++ b/src/amane/db/repos/media.py
@@ -6,6 +6,7 @@ from sqlalchemy.sql.functions import count
 from sqlmodel import col, select
 
 from ...parsing import ContentType, FilePhase, FilePhaseSummary, Mosaic, file_phase_from_path, summarize_file_phases
+from ...utils.path import nfc_path
 from ..models import MediaFile, MediaFileStatus, MediaSortField, SortOrder
 from ..repo_types import _MEDIA_SORT_COLUMNS, MediaFileUpdates, _apply_media_phase_filters, _order_clause, _utcnow
 from .base import RepositoryMixinBase
@@ -40,6 +41,9 @@ class MetadataFilesSummary(NamedTuple):
 
 class MediaRepoMixin(RepositoryMixinBase):
     async def create_media_file(self, library_id: int, **updates: Unpack[MediaFileUpdates]) -> MediaFile:
+        path = updates.get("path")
+        if path is not None:
+            updates["path"] = nfc_path(path)
         async with self._session() as session:
             media = MediaFile(library_id=library_id, **updates)
             _apply_path_phase(media)
@@ -54,13 +58,13 @@ class MediaRepoMixin(RepositoryMixinBase):
 
     async def get_media_file_by_path(self, path: str) -> MediaFile | None:
         async with self._session() as session:
-            stmt = select(MediaFile).where(MediaFile.path == path)
+            stmt = select(MediaFile).where(MediaFile.path == nfc_path(path))
             result = await session.exec(stmt)
             return result.first()
 
     async def get_valid(self, disk_paths: Iterable[str]) -> Sequence[MediaFile]:
-        """路径按 SQL_IN_CHUNK_SIZE 分批 IN, 避开绑定变量上限."""
-        paths = list(disk_paths)
+        """路径按 SQL_IN_CHUNK_SIZE 分批 IN, 避开绑定变量上限. 比较前统一 NFC."""
+        paths = [nfc_path(p) for p in disk_paths]
         if not paths:
             return []
         found: list[MediaFile] = []
@@ -79,10 +83,10 @@ class MediaRepoMixin(RepositoryMixinBase):
         if library_id is None and not disk_paths:
             return []
         files = await self.list_media_files(library_id=library_id, limit=None)
-        disk = frozenset(disk_paths)
+        disk = frozenset(nfc_path(p) for p in disk_paths)
         if not disk:
             return files
-        return [f for f in files if f.path not in disk]
+        return [f for f in files if nfc_path(f.path) not in disk]
 
     async def list_media_files(
         self,
@@ -170,7 +174,7 @@ class MediaRepoMixin(RepositoryMixinBase):
                 return None
             # 显式赋值, 禁止 setattr; 字段集由 MediaFileUpdates 与 MediaFile 静态对齐.
             if "path" in updates:
-                media.path = updates["path"]
+                media.path = nfc_path(updates["path"])
                 _apply_path_phase(media)
             if "number" in updates:
                 media.number = updates["number"]

--- a/src/amane/handlers/_common.py
+++ b/src/amane/handlers/_common.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from ..db import MediaFileStatus
 from ..library import LibraryHit, LibraryScan
 from ..utils.oshash import compute_oshash
-from ..utils.threads import in_thread
+from ..utils.threads import existing_disk_path, in_thread
 
 if TYPE_CHECKING:
     from ..db.models import MediaFile
@@ -43,7 +43,10 @@ async def ensure_oshash(repo: Repository, media: MediaFile) -> str | None:
     """已有指纹直接返回; 计算失败留 None, 不阻断刮削."""
     if media.oshash is not None:
         return media.oshash
-    media_hash = await compute_oshash(Path(media.path))
+    disk = await existing_disk_path(Path(media.path))
+    if disk is None:
+        return None
+    media_hash = await compute_oshash(disk)
     if media_hash is None or media.id is None:
         return None
     updated = await repo.update_media_file(media.id, oshash=media_hash)

--- a/src/amane/handlers/file.py
+++ b/src/amane/handlers/file.py
@@ -25,7 +25,8 @@ from ..organize import (
 from ..organize.file import OrganizeResult as DiskOrganizeResult
 from ..organize.link import create_video_link
 from ..parsing import FileInfo, parse_file_info
-from ..utils.threads import in_thread, path_exists, path_is_dir
+from ..utils.path import existing_disk_path as existing_disk_path_sync
+from ..utils.threads import existing_disk_path, in_thread, path_is_dir
 from ._common import scan_library
 from .models import CleanupPayload, CleanupResult, OrganizePayload, OrganizeResult
 from .protocol import TaskHandler, TaskResult
@@ -64,9 +65,9 @@ async def execute_file_operations(
     watermark_dir: Path | None = None,
     actor_genders: dict[str, ActorGender] | None = None,
 ) -> FileOperationsResult:
-    source_path = Path(media_file.path)
-    if not await path_exists(source_path):
-        logger.warning("source file missing", path=str(source_path))
+    source_path = await existing_disk_path(Path(media_file.path))
+    if source_path is None:
+        logger.warning("source file missing", path=media_file.path)
         return FileOperationsResult(success=False, error=f"Source file not found: {media_file.path}")
 
     info = file_info if file_info is not None else parse_file_info(source_path)
@@ -377,7 +378,7 @@ class OrganizeHandler(TaskHandler[OrganizePayload, OrganizeResult]):
         if prune_total:
             await self.report_progress(0, prune_total, "prune")
             for i, mf in enumerate(indexed, start=1):
-                if mf.id is not None and not await path_exists(Path(mf.path), follow_symlinks=False):
+                if mf.id is not None and await existing_disk_path(Path(mf.path), follow_symlinks=False) is None:
                     await self._repo.delete_media_file(mf.id)
                 await self.report_progress(i, prune_total, "prune")
 
@@ -541,7 +542,7 @@ async def _collect_live_resource_refs(repo: Repository) -> tuple[set[str], set[s
 @in_thread
 def _missing_media_ids(rows: Sequence[tuple[int, str]]) -> list[int]:
     """不跟随符号链接判断存在."""
-    return [media_id for media_id, path in rows if not Path(path).exists(follow_symlinks=False)]
+    return [media_id for media_id, path in rows if existing_disk_path_sync(path, follow_symlinks=False) is None]
 
 
 class CleanupHandler(TaskHandler[CleanupPayload, CleanupResult]):

--- a/src/amane/handlers/refresh.py
+++ b/src/amane/handlers/refresh.py
@@ -7,6 +7,7 @@ import structlog
 from ..db import TaskType
 from ..library import MEDIA_EXTENSIONS, LibraryFileKind, LibraryScan
 from ..parsing import parse_file_info
+from ..utils.path import nfc_path
 from ..utils.threads import path_exists, path_is_dir
 from ._common import register_media_file, scan_library
 from .models import RefreshPayload, RefreshResult, ScanMode, ScrapePayload
@@ -43,7 +44,7 @@ class RefreshHandler(TaskHandler[RefreshPayload, RefreshResult]):
         added = removed = scrape = 0
 
         existing = await self._repo.list_media_files(library_id=payload.library_id, limit=None)
-        existing_by_path = {f.path: f for f in existing}
+        existing_by_path = {nfc_path(f.path): f for f in existing}
 
         if payload.scan:
             want_add = ScanMode.add in payload.scan
@@ -63,15 +64,15 @@ class RefreshHandler(TaskHandler[RefreshPayload, RefreshResult]):
                     if hit.kind is not LibraryFileKind.MEDIA:
                         continue
                     file_path = hit.path
-                    path_str = str(file_path)
+                    path_key = nfc_path(str(file_path))
                     walked += 1
                     if seen is not None:
-                        seen.add(path_str)
+                        seen.add(path_key)
                     if walked % _WALK_LOG_EVERY == 0:
                         logger.info("scan walking", path=payload.path, seen=walked, added=added)
-                    if path_str not in existing_by_path:
+                    if path_key not in existing_by_path:
                         media = await register_media_file(self._repo, payload.library_id, file_path)
-                        existing_by_path[path_str] = media
+                        existing_by_path[path_key] = media
                         added += 1
                 if added:
                     logger.info("new files discovered", path=payload.path, count=added)
@@ -79,7 +80,7 @@ class RefreshHandler(TaskHandler[RefreshPayload, RefreshResult]):
             # 删除索引中已不存在的记录.
             if want_remove:
                 if seen is not None:
-                    missing = [f for f in existing if f.path not in seen]
+                    missing = [f for f in existing if nfc_path(f.path) not in seen]
                 else:
                     missing = []
                     for f in existing:

--- a/src/amane/organize/file.py
+++ b/src/amane/organize/file.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import structlog
 
 from ..enums import MoveMode
+from ..utils.path import existing_disk_path
 from ..utils.threads import in_thread
 
 logger = structlog.get_logger()
@@ -25,17 +26,17 @@ def execute_organize(
     *,
     suffix: str | None = None,
 ) -> OrganizeResult:
-    # 校验源文件存在.
-    if not source.exists():
+    disk_source = existing_disk_path(source)
+    if disk_source is None:
         logger.warning("organize source not found", source=str(source))
         return OrganizeResult(success=False, error=f"Source not found: {source}")
 
     try:
         target_dir.mkdir(parents=True, exist_ok=True)
-        dest_suffix = source.suffix if suffix is None else suffix
+        dest_suffix = disk_source.suffix if suffix is None else suffix
         dest = target_dir / f"{target_stem}{dest_suffix}"
         # 已就位则跳过碰撞改名.
-        if _already_at_dest(source, dest):
+        if _already_at_dest(disk_source, dest):
             return OrganizeResult(success=True, dest=dest)
 
         # 目标占用时追加 (1), (2).
@@ -43,13 +44,13 @@ def execute_organize(
 
         match mode:
             case MoveMode.MOVE:
-                source.move(dest)
+                disk_source.move(dest)
             case MoveMode.COPY:
-                source.copy(dest)
+                disk_source.copy(dest)
             case MoveMode.HARDLINK:
-                dest.hardlink_to(source)
+                dest.hardlink_to(disk_source)
             case MoveMode.SYMLINK:
-                dest.symlink_to(source)
+                dest.symlink_to(disk_source)
 
         logger.debug("file organized", source=source.name, dest=str(dest), mode=mode)
         return OrganizeResult(success=True, dest=dest)
@@ -61,16 +62,17 @@ def execute_organize(
 
 def _already_at_dest(source: Path, dest: Path) -> bool:
     """源与模板 dest 已是同一文件 (含硬链) 则视为已整理, 不触发碰撞改名."""
-    if not dest.exists():
+    dest_on_disk = existing_disk_path(dest)
+    if dest_on_disk is None:
         return False
     try:
-        return source.samefile(dest)
+        return source.samefile(dest_on_disk)
     except OSError:
         return False
 
 
 def _resolve_collision(dest: Path) -> Path:
-    if not dest.exists():
+    if existing_disk_path(dest) is None:
         return dest
     stem = dest.stem
     suffix = dest.suffix
@@ -78,6 +80,6 @@ def _resolve_collision(dest: Path) -> Path:
     i = 1
     while True:
         candidate = parent / f"{stem}({i}){suffix}"
-        if not candidate.exists():
+        if existing_disk_path(candidate) is None:
             return candidate
         i += 1

--- a/src/amane/utils/path.py
+++ b/src/amane/utils/path.py
@@ -1,8 +1,8 @@
-import os
-from typing import TYPE_CHECKING
+from __future__ import annotations
 
-if TYPE_CHECKING:
-    from pathlib import Path
+import os
+import unicodedata
+from pathlib import Path
 
 
 def _resolve_or_literal(p: str | Path) -> str:
@@ -40,3 +40,32 @@ def is_descendant(p: str | Path, parent: str | Path) -> bool:
 
 def is_any_descendant(p: str | Path, *parents: str | Path) -> bool:
     return any(is_descendant(p, parent) for parent in parents)
+
+
+def nfc_path(path: str) -> str:
+    """库内路径身份一律 NFC.
+
+    MediaFile.path 的写入、按路径查找、与库内路径做集合差必须经过此函数.
+    """
+    return unicodedata.normalize("NFC", path)
+
+
+def path_forms(path: str | Path) -> tuple[Path, ...]:
+    """磁盘 I/O 候选: 传入形式, 再补规范等价的 NFC / NFD (去重, 保序)."""
+    raw = os.fspath(path)
+    forms: list[Path] = []
+    seen: set[str] = set()
+    for text in (raw, nfc_path(raw), unicodedata.normalize("NFD", raw)):
+        if text in seen:
+            continue
+        seen.add(text)
+        forms.append(Path(text))
+    return tuple(forms)
+
+
+def existing_disk_path(path: str | Path, *, follow_symlinks: bool = True) -> Path | None:
+    """返回磁盘上存在的第一种形式. Linux / Windows 上 NFC 与 NFD 是不同文件名."""
+    for candidate in path_forms(path):
+        if candidate.exists(follow_symlinks=follow_symlinks):
+            return candidate
+    return None

--- a/src/amane/utils/threads.py
+++ b/src/amane/utils/threads.py
@@ -8,6 +8,8 @@ from functools import update_wrapper
 from pathlib import Path
 from typing import Any
 
+from .path import existing_disk_path as _existing_disk_path
+
 
 class in_thread[**P, R]:
     """``await fn(...)`` 进入线程池, ``fn.sync(...)`` 原地执行."""
@@ -23,8 +25,14 @@ class in_thread[**P, R]:
 
 
 @in_thread
+def existing_disk_path(path: Path, *, follow_symlinks: bool = True) -> Path | None:
+    """先试传入路径, 不存在再试规范等价的 NFC / NFD."""
+    return _existing_disk_path(path, follow_symlinks=follow_symlinks)
+
+
+@in_thread
 def path_exists(path: Path, *, follow_symlinks: bool = True) -> bool:
-    return path.exists(follow_symlinks=follow_symlinks)
+    return _existing_disk_path(path, follow_symlinks=follow_symlinks) is not None
 
 
 @in_thread

--- a/tests/db/test_nfc_media_file_paths_migration.py
+++ b/tests/db/test_nfc_media_file_paths_migration.py
@@ -37,9 +37,9 @@ def test_nfc_media_file_paths_rewrites_and_merges(tmp_path: Path) -> None:
             text(
                 "INSERT INTO media_files "
                 "(path, status, library_id, created_at, updated_at, content_type, has_subtitle) VALUES "
-                "(:nfd, 'pending', :lib, '2026-01-01 00:00:00', '2026-01-01 00:00:00', 'WESTERN', 0), "
-                "(:nfc, 'scraped', :lib, '2026-01-01 00:00:00', '2026-01-01 00:00:00', 'WESTERN', 0), "
-                "(:other, 'pending', :lib, '2026-01-01 00:00:00', '2026-01-01 00:00:00', 'WESTERN', 0)"
+                "(:nfd, 'PENDING', :lib, '2026-01-01 00:00:00', '2026-01-01 00:00:00', 'WESTERN', 0), "
+                "(:nfc, 'SCRAPED', :lib, '2026-01-01 00:00:00', '2026-01-01 00:00:00', 'WESTERN', 0), "
+                "(:other, 'PENDING', :lib, '2026-01-01 00:00:00', '2026-01-01 00:00:00', 'WESTERN', 0)"
             ),
             {"nfd": nfd, "nfc": nfc, "other": other_nfd, "lib": lib_id},
         )
@@ -49,6 +49,6 @@ def test_nfc_media_file_paths_rewrites_and_merges(tmp_path: Path) -> None:
     with engine.connect() as conn:
         rows = conn.execute(text("SELECT path, status FROM media_files ORDER BY path")).all()
 
-    assert {(row.path, row.status) for row in rows} == {(nfc, "scraped"), (other_nfc, "pending")}
+    assert {(row.path, row.status) for row in rows} == {(nfc, "SCRAPED"), (other_nfc, "PENDING")}
 
     engine.dispose()

--- a/tests/db/test_nfc_media_file_paths_migration.py
+++ b/tests/db/test_nfc_media_file_paths_migration.py
@@ -1,0 +1,54 @@
+"""迁移: MediaFile.path 改为 NFC, 同一 NFC 路径只留一行."""
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+
+def test_nfc_media_file_paths_rewrites_and_merges(tmp_path: Path) -> None:
+    db_path = tmp_path / "migrate.db"
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+
+    command.upgrade(cfg, "9d6cb1706ad1")
+
+    nfc = "/video/\u3058.mp4"
+    nfd = "/video/\u3057\u3099.mp4"
+    other_nfd = "/other/\u3057\u3099.mp4"
+    other_nfc = "/other/\u3058.mp4"
+    assert nfc != nfd
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO libraries "
+                "(name, path, automation, recursive, patterns, move_mode, link_mode, video_template, "
+                "write_nfo, copy_resources, trailer_pattern, blacklist_patterns, subtitle_extensions, "
+                "min_file_size) "
+                "VALUES ('t', '/m', 'SCRAPE', 1, '[]', 'MOVE', 'STRM', '{number}.{ext}', 1, "
+                "'[]', '', '[]', '[]', 0)"
+            )
+        )
+        lib_id = conn.execute(text("SELECT id FROM libraries")).scalar_one()
+        conn.execute(
+            text(
+                "INSERT INTO media_files "
+                "(path, status, library_id, created_at, updated_at, content_type, has_subtitle) VALUES "
+                "(:nfd, 'pending', :lib, '2026-01-01 00:00:00', '2026-01-01 00:00:00', 'WESTERN', 0), "
+                "(:nfc, 'scraped', :lib, '2026-01-01 00:00:00', '2026-01-01 00:00:00', 'WESTERN', 0), "
+                "(:other, 'pending', :lib, '2026-01-01 00:00:00', '2026-01-01 00:00:00', 'WESTERN', 0)"
+            ),
+            {"nfd": nfd, "nfc": nfc, "other": other_nfd, "lib": lib_id},
+        )
+
+    command.upgrade(cfg, "head")
+
+    with engine.connect() as conn:
+        rows = conn.execute(text("SELECT path, status FROM media_files ORDER BY path")).all()
+
+    assert {(row.path, row.status) for row in rows} == {(nfc, "scraped"), (other_nfc, "pending")}
+
+    engine.dispose()

--- a/tests/db/test_repository.py
+++ b/tests/db/test_repository.py
@@ -67,6 +67,27 @@ class TestMediaFileRepo:
         assert await repo.get_media_file_by_path("/nonexistent") is None
 
     @pytest.mark.asyncio(loop_scope="function")
+    async def test_path_identity_is_nfc(self, repo: Repository):
+        """写入与按路径查找一律 NFC; NFD 查询命中已存的 NFC 行."""
+        nfc = "/video/\u3058.mp4"
+        nfd = "/video/\u3057\u3099.mp4"
+        assert nfc != nfd
+        created = await repo.create_media_file(library_id=1, path=nfd, number="NFC-1")
+        assert created.id is not None
+        assert created.path == nfc
+        found = await repo.get_media_file_by_path(nfd)
+        assert found is not None
+        assert found.id == created.id
+        assert found.path == nfc
+        updated = await repo.update_media_file(created.id, path=nfd)
+        assert updated is not None
+        assert updated.path == nfc
+        valid = await repo.get_valid([nfd])
+        assert {f.id for f in valid} == {created.id}
+        invalid = await repo.get_invalid([nfd], library_id=1)
+        assert all(f.id != created.id for f in invalid)
+
+    @pytest.mark.asyncio(loop_scope="function")
     async def test_update_status(self, repo: Repository):
         media = await repo.create_media_file(library_id=1, path="/video/X.mp4")
         assert media.id is not None

--- a/tests/handlers/test_scraper.py
+++ b/tests/handlers/test_scraper.py
@@ -10,6 +10,7 @@ from amane.crawlers.models import MediaMetadata
 from amane.db.models import MediaFileStatus, TaskType
 from amane.enums import MetadataField, SiteName
 from amane.handlers import RefreshHandler, RefreshPayload, ScanMode, ScrapeHandler, ScrapePayload
+from amane.library import LibraryFileKind, LibraryHit
 from amane.parsing import ContentType
 
 if TYPE_CHECKING:
@@ -554,6 +555,61 @@ class TestRefreshHandler:
         assert result.result.removed == 1
         assert await repo.get_media_file_by_path(str(keep)) is not None
         assert await repo.get_media_file_by_path(str(tmp_path / "missing.mp4")) is None
+
+    @pytest.mark.asyncio(loop_scope="function")
+    async def test_remove_only_keeps_nfd_file_indexed_as_nfc(self, repo: Repository, tmp_path):
+        """仅 remove 用库内 NFC 判断存在时, 磁盘 NFD 文件不得当作缺失."""
+        nfd = tmp_path / "\u3057\u3099.mp4"
+        nfd.write_bytes(b"\x00" * 100)
+        lib = await repo.create_library(name="t", path=str(tmp_path))
+        assert lib.id is not None
+        media = await repo.create_media_file(lib.id, path=str(nfd))
+        assert media.id is not None
+        assert media.path == str(tmp_path / "\u3058.mp4")
+
+        result = await RefreshHandler(repo=repo).handle(
+            RefreshPayload(library_id=lib.id, path=str(tmp_path), scan={ScanMode.remove}, scrape=set())
+        )
+        assert result.success is True
+        assert result.result is not None
+        assert result.result.removed == 0
+        assert await repo.get_media_file(media.id) is not None
+
+    @pytest.mark.asyncio(loop_scope="function")
+    async def test_scan_nfc_identity_does_not_add_or_remove(
+        self, repo: Repository, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """目录列出 NFD、库内已是 NFC 时, add+remove 不新增也不删除."""
+        nfc = "\u3058"
+        nfd = "\u3057\u3099"
+        lib = await repo.create_library(name="t", path=str(tmp_path))
+        assert lib.id is not None
+        stored = tmp_path / f"{nfc}.mp4"
+        stored.write_bytes(b"\x00" * 100)
+        media = await repo.create_media_file(lib.id, path=str(stored))
+        assert media.path == str(stored)
+
+        listed = tmp_path / f"{nfd}.mp4"
+
+        async def fake_scan(*_args: object, **_kwargs: object) -> list[LibraryHit]:
+            return [LibraryHit(listed, LibraryFileKind.MEDIA)]
+
+        monkeypatch.setattr("amane.handlers.refresh.scan_library", fake_scan)
+        result = await RefreshHandler(repo=repo).handle(
+            RefreshPayload(
+                library_id=lib.id,
+                path=str(tmp_path),
+                scan={ScanMode.add, ScanMode.remove},
+                scrape=set(),
+            )
+        )
+        assert result.success is True
+        assert result.result is not None
+        assert result.result.added == 0
+        assert result.result.removed == 0
+        files = await repo.list_media_files(library_id=lib.id, limit=None)
+        assert [f.id for f in files] == [media.id]
+        assert files[0].path == str(stored)
 
     @pytest.mark.parametrize(
         ("scan_modes", "scrape_statuses", "expected_scrape_tasks"),

--- a/tests/organize/test_file_org.py
+++ b/tests/organize/test_file_org.py
@@ -94,6 +94,24 @@ class TestExecuteOrganize:
         assert dest.read_text() == "content"
         assert not (target_dir / "MIDV-123(1).mp4").exists()
 
+    def test_move_resolves_nfd_source_from_nfc_path(self, tmp_path: Path):
+        """库内 NFC 路径对应磁盘 NFD 文件时仍能打开并移动."""
+        nfd = "\u3057\u3099"
+        nfc = "\u3058"
+        src_nfd = tmp_path / "src" / f"{nfd}.mp4"
+        src_nfd.parent.mkdir()
+        src_nfd.write_text("video")
+        result = execute_organize.sync(
+            source=tmp_path / "src" / f"{nfc}.mp4",
+            target_dir=tmp_path / "out",
+            target_stem="SSIS-914",
+            mode=MoveMode.MOVE,
+        )
+        assert result.success is True
+        dest = tmp_path / "out" / "SSIS-914.mp4"
+        assert dest.read_text() == "video"
+        assert not src_nfd.exists()
+
     def test_already_hardlinked_dest_is_success(self, tmp_path: Path):
         """源与 dest 不同路径但同一 inode 时也不碰撞改名."""
         src = tmp_path / "src.mp4"

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from amane.utils.path import is_descendant
+from amane.utils.path import existing_disk_path, is_descendant, nfc_path, path_forms
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="此测试不适用于 Windows")
@@ -84,3 +84,46 @@ def test_is_descendant_mixed_forms_fail_closed(monkeypatch):
 
     monkeypatch.setattr(os.path, "realpath", fake_realpath)
     assert is_descendant(r"\\?\C:\Users\Test", r"C:\Users") is False
+
+
+# じ: NFC = U+3058; NFD = し + 组合用浊点.
+_NFC_JI = "\u3058"
+_NFD_JI = "\u3057\u3099"
+
+
+@pytest.mark.parametrize(
+    ("raw", "want"),
+    [
+        (f"/a/{_NFC_JI}.mp4", f"/a/{_NFC_JI}.mp4"),
+        (f"/a/{_NFD_JI}.mp4", f"/a/{_NFC_JI}.mp4"),
+        (f"/a/{_NFD_JI}/{_NFC_JI}.mp4", f"/a/{_NFC_JI}/{_NFC_JI}.mp4"),
+        ("/ascii/foo.mp4", "/ascii/foo.mp4"),
+        ("", ""),
+    ],
+)
+def test_nfc_path(raw: str, want: str) -> None:
+    assert nfc_path(raw) == want
+    assert nfc_path(raw) == nfc_path(nfc_path(raw))
+
+
+@pytest.mark.parametrize(
+    ("raw", "want"),
+    [
+        ("/a/foo.mp4", ("/a/foo.mp4",)),
+        (f"/a/{_NFC_JI}.mp4", (f"/a/{_NFC_JI}.mp4", f"/a/{_NFD_JI}.mp4")),
+        (f"/a/{_NFD_JI}.mp4", (f"/a/{_NFD_JI}.mp4", f"/a/{_NFC_JI}.mp4")),
+    ],
+)
+def test_path_forms(raw: str, want: tuple[str, ...]) -> None:
+    assert tuple(p.as_posix() for p in path_forms(raw)) == want
+
+
+def test_existing_disk_path_tries_nfd(tmp_path: Path) -> None:
+    """磁盘为 NFD 时, 用 NFC 查询仍返回可打开的路径."""
+    nfd = tmp_path / f"{_NFD_JI}.mp4"
+    nfd.write_bytes(b"x")
+    nfc = tmp_path / f"{_NFC_JI}.mp4"
+    found = existing_disk_path(nfc)
+    assert found is not None
+    assert found.read_bytes() == b"x"
+    assert existing_disk_path(tmp_path / "missing.mp4") is None


### PR DESCRIPTION
> ❗ **此 PR 包含 DB migration**

## Summary
- `MediaFile.path` 的写入、按路径查找、有效 / 失效集合差一律 NFC, 避免 HFS+ / 部分网络盘列出 NFD 后再次扫描插入第二行, 二次整理违反 UNIQUE.
- 从库内路径打开、判断存在、落盘经 `existing_disk_path`: 先试传入形式, 再试规范等价的 NFC / NFD. Linux / Windows 上两种形式是不同文件名.
- 升级时将存量路径改为 NFC, 同一 NFC 路径只留一行. 扫描不会改写已有 path, 不能代替这次迁移.

## Test plan
- [ ] 库内已有 NFC 行、目录列出 NFD 时, 扫描 add+remove 不新增也不删除
- [ ] 仅 remove / CLEANUP / ORGANIZE prune 用库内 NFC 判断存在时, 磁盘 NFD 文件保留
- [ ] 整理以库内 NFC 打开磁盘 NFD 源文件可以移动; 回写 dest 为 NFC, 不违反 UNIQUE
- [ ] 升级后成对的 NFC / NFD 行合并为一条 NFC, 单独的 NFD 行改为 NFC

Fix #108