### PR TITLE
fix: 定时任务选择器按本地时间换算为 UTC cron

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -43,7 +43,7 @@ Tabs 同时挂载全部条目, 叶子 `id`/`htmlFor` 必须经由 `useFieldDomId
 
 `/plugins` 通过 `/api/plugins` 取得插件自带 JSON Schema, 单独渲染每个来源配置; 插件配置不进入核心 HotSettings 表单. 安装用 `PathPicker` 选服务器目录/zip, 或上传本机 zip; 重新扫描 / 卸载经由同一资源的 POST/DELETE, 成功后同时失效插件列表与 config schema (路由 enum 会变).
 
-任务 / 定时提交用 `DiscriminatedSchemaForm`: 外部选 `type` → schema variant → 去掉 const `type` 后交给 `create` 模式. 短枚举共用 `EnumToggle` (`components/common/enum-toggle.tsx`): 项间分隔线 + 滑动指示; `fullWidth` 占据整行 (任务/定时 type、cron 模式、订阅内容类型), 默认按文案宽度 (Schema 表单短枚举、库放置方式/自动化、间隔单位). 片库 grid/list 等页面 view 切换仍用 SegmentedControl. 定时的 cron 用 `CronPicker`: 可视化覆盖间隔/每天/每周/每月, 无法往返的表达式回落「高级」手写; 产出 5-field, 与后端 croniter 一致.
+任务 / 定时提交用 `DiscriminatedSchemaForm`: 外部选 `type` → schema variant → 去掉 const `type` 后交给 `create` 模式. 短枚举共用 `EnumToggle` (`components/common/enum-toggle.tsx`): 项间分隔线 + 滑动指示; `fullWidth` 占据整行 (任务/定时 type、cron 模式、订阅内容类型), 默认按文案宽度 (Schema 表单短枚举、库放置方式/自动化、间隔单位). 片库 grid/list 等页面 view 切换仍用 SegmentedControl. 定时的 cron 用 `CronPicker`: 可视化覆盖间隔/每天/每周/每月, 无法往返的表达式回落「高级」手写; 产出 5-field, 与后端 croniter 一致. 每天/每周/每月的时刻按浏览器本地墙钟填写, 写出时换算为 UTC 字段 (星期与日期随跨日平移); 间隔不换算; 「高级」手写按 UTC.
 
 Library 表单仍手写 (create/edit 差 + `scan` 条件字段 + 库级 `automation` / 整理默认与预告片跳过正则); 路径模板占位符与后端 `resolve_paths` 同源, 经由 `GET /api/libraries/path-template-schema` 下发 name+map_keys, 徽章说明在 i18n `placeholders.items` (有闭合取值时 tooltip 附 `map_keys`); 可空占位符名带字面量 `?`, `{name|k=v}` 与可选组语法见 [data-model.md](data-model.md). 模板框是透明输入叠着色层 (`template-input.tsx`), 词法跟 Parser 的 `{name}` / `|k=v` / `[..]` / `[[..]]`; Accordion Collapse 展开时盒子从 0 增至目标高度; 着色层须在尺寸变化后再次与输入框对齐 (有值时输入框透明, overlay 高度为 0 会裁掉文字); 占位符名与有闭合取值的映射 key 对照 `path-template-schema` 标红, 清单未下发时只标语法错误.
 

--- a/web/src/components/cron-picker/cron-picker.tsx
+++ b/web/src/components/cron-picker/cron-picker.tsx
@@ -253,40 +253,42 @@ function TimeSelects({
 }) {
   const { t } = useTranslation("schedules");
   return (
-    <Group gap="xs" align="flex-end" wrap="nowrap">
-      {!hourHidden && (
+    <Input.Wrapper description={hourHidden ? undefined : t("cron.localTime")} size="sm">
+      <Group gap="xs" align="flex-end" wrap="nowrap">
+        {!hourHidden && (
+          <Select
+            label={t("cron.hour")}
+            data={HOUR_OPTIONS}
+            value={String(hour)}
+            allowDeselect={false}
+            searchable
+            disabled={disabled}
+            w={88}
+            comboboxProps={SELECT_COMBOBOX}
+            onChange={(v) => {
+              const next = parseClockField(v, 0, 23);
+              if (next === null) return;
+              onChange(next, minute);
+            }}
+          />
+        )}
         <Select
-          label={t("cron.hour")}
-          data={HOUR_OPTIONS}
-          value={String(hour)}
+          label={hourHidden ? t("cron.minuteOfHour") : t("cron.minute")}
+          data={MINUTE_OPTIONS}
+          value={String(minute)}
           allowDeselect={false}
           searchable
           disabled={disabled}
           w={88}
           comboboxProps={SELECT_COMBOBOX}
           onChange={(v) => {
-            const next = parseClockField(v, 0, 23);
+            const next = parseClockField(v, 0, 59);
             if (next === null) return;
-            onChange(next, minute);
+            onChange(hour, next);
           }}
         />
-      )}
-      <Select
-        label={hourHidden ? t("cron.minuteOfHour") : t("cron.minute")}
-        data={MINUTE_OPTIONS}
-        value={String(minute)}
-        allowDeselect={false}
-        searchable
-        disabled={disabled}
-        w={88}
-        comboboxProps={SELECT_COMBOBOX}
-        onChange={(v) => {
-          const next = parseClockField(v, 0, 59);
-          if (next === null) return;
-          onChange(hour, next);
-        }}
-      />
-    </Group>
+      </Group>
+    </Input.Wrapper>
   );
 }
 

--- a/web/src/i18n/locales/en/schedules.json
+++ b/web/src/i18n/locales/en/schedules.json
@@ -27,8 +27,9 @@
     "hour": "Hour",
     "minute": "Minute",
     "minuteOfHour": "At minute",
+    "localTime": "Local time",
     "customPlaceholder": "minute hour day month weekday",
-    "customHint": "Standard 5-field Cron, same as Linux crontab",
+    "customHint": "Standard 5-field Cron, same as Linux crontab. Times are UTC",
     "dayJoiner": ", ",
     "weekdays": {
       "sun": "Sun",

--- a/web/src/i18n/locales/zh-CN/schedules.json
+++ b/web/src/i18n/locales/zh-CN/schedules.json
@@ -27,8 +27,9 @@
     "hour": "时",
     "minute": "分",
     "minuteOfHour": "第几分钟",
+    "localTime": "本地时间",
     "customPlaceholder": "分 时 日 月 星期",
-    "customHint": "标准 5 段 Cron, 与 Linux crontab 相同",
+    "customHint": "标准 5 段 Cron, 与 Linux crontab 相同. 时刻按 UTC",
     "dayJoiner": "、",
     "weekdays": {
       "sun": "日",

--- a/web/src/lib/cron.ts
+++ b/web/src/lib/cron.ts
@@ -1,11 +1,13 @@
 /**
  * 5-field cron (minute hour day-of-month month day-of-week).
  * 与后端 croniter 默认格式一致; 只解析可视化选择器能往返的常见模式, 其余视为 custom.
+ *
+ * CronValue 的 hour / minute / days / day 是浏览器本地墙钟.
+ * formatCron 写出 UTC 字段; parseCron 把 UTC 字段换算回本地.
+ * interval 与 custom 不换算 — custom 按 UTC 手写.
  */
 
 import { assertNever, exhaustiveTuple, isOneOf } from "./exhaustive";
-
-export const DEFAULT_CRON = "0 2 * * *";
 
 export type CronKind = "interval" | "daily" | "weekly" | "monthly" | "custom";
 export type IntervalUnit = "minutes" | "hours";
@@ -55,7 +57,7 @@ export function parseCron(expression: string): CronValue {
   if (!trimmed) return { kind: "custom", expression: "" };
 
   const macro = MACROS[trimmed.toLowerCase()];
-  if (macro) return macro;
+  if (macro) return fromUtcValue(macro);
 
   const fields = trimmed.split(/\s+/);
   if (fields.length !== 5) return { kind: "custom", expression: trimmed };
@@ -93,18 +95,18 @@ export function parseCron(expression: string): CronValue {
   if (minute === null || hour === null) return { kind: "custom", expression: trimmed };
 
   if (domF === "*" && dowF === "*") {
-    return { kind: "daily", hour, minute };
+    return fromUtcValue({ kind: "daily", hour, minute });
   }
 
   if (domF === "*") {
     const days = parseDowList(dowF);
-    if (days) return { kind: "weekly", hour, minute, days };
+    if (days) return fromUtcValue({ kind: "weekly", hour, minute, days });
     return { kind: "custom", expression: trimmed };
   }
 
   const day = parseSingle(domF, 1, 31);
   if (day !== null && dowF === "*") {
-    return { kind: "monthly", hour, minute, day };
+    return fromUtcValue({ kind: "monthly", hour, minute, day });
   }
 
   return { kind: "custom", expression: trimmed };
@@ -120,21 +122,42 @@ export function formatCron(value: CronValue): string {
       }
       return every === 1 ? `${minute} * * * *` : `${minute} */${every} * * *`;
     }
-    case "daily":
-      return `${clampInt(value.minute, 0, 59)} ${clampInt(value.hour, 0, 23)} * * *`;
-    case "weekly": {
-      const days = uniqueSortedDays(value.days);
-      const dow = days.length === 0 ? "*" : days.join(",");
-      return `${clampInt(value.minute, 0, 59)} ${clampInt(value.hour, 0, 23)} * * ${dow}`;
+    case "daily": {
+      const utc = toUtcValue({
+        kind: "daily",
+        hour: clampInt(value.hour, 0, 23),
+        minute: clampInt(value.minute, 0, 59),
+      });
+      return `${utc.minute} ${utc.hour} * * *`;
     }
-    case "monthly":
-      return `${clampInt(value.minute, 0, 59)} ${clampInt(value.hour, 0, 23)} ${clampInt(value.day, 1, 31)} * *`;
+    case "weekly": {
+      const utc = toUtcValue({
+        kind: "weekly",
+        hour: clampInt(value.hour, 0, 23),
+        minute: clampInt(value.minute, 0, 59),
+        days: uniqueSortedDays(value.days),
+      });
+      const dow = utc.days.length === 0 ? "*" : utc.days.join(",");
+      return `${utc.minute} ${utc.hour} * * ${dow}`;
+    }
+    case "monthly": {
+      const utc = toUtcValue({
+        kind: "monthly",
+        hour: clampInt(value.hour, 0, 23),
+        minute: clampInt(value.minute, 0, 59),
+        day: clampInt(value.day, 1, 31),
+      });
+      return `${utc.minute} ${utc.hour} ${utc.day} * *`;
+    }
     case "custom":
       return value.expression.trim();
     default:
       return assertNever(value, "CronValue");
   }
 }
+
+/** 每天本地 02:00, 写出时换算为 UTC. */
+export const DEFAULT_CRON = formatCron({ kind: "daily", hour: 2, minute: 0 });
 
 export function toInterval(value: CronValue): IntervalCron {
   if (value.kind === "interval") return value;
@@ -190,6 +213,72 @@ export function isUsableCron(expression: string): boolean {
     return trimmed.startsWith("@") || trimmed.split(/\s+/).length >= 5;
   }
   return true;
+}
+
+function tzOffsetMin(): number {
+  return new Date().getTimezoneOffset();
+}
+
+function shiftClock(
+  hour: number,
+  minute: number,
+  offsetMin: number,
+): { hour: number; minute: number; dayDelta: number } {
+  const total = hour * 60 + minute + offsetMin;
+  const dayDelta = Math.floor(total / (24 * 60));
+  const wrapped = ((total % (24 * 60)) + 24 * 60) % (24 * 60);
+  return { hour: Math.floor(wrapped / 60), minute: wrapped % 60, dayDelta };
+}
+
+function shiftWeekdays(days: readonly Weekday[], dayDelta: number): Weekday[] {
+  const shifted: Weekday[] = [];
+  for (const day of days) {
+    const next = (((day + dayDelta) % 7) + 7) % 7;
+    if (isOneOf(WEEKDAYS, next)) shifted.push(next);
+  }
+  return uniqueSortedDays(shifted);
+}
+
+function shiftMonthDay(day: number, dayDelta: number): number {
+  return ((((day - 1 + dayDelta) % 31) + 31) % 31) + 1;
+}
+
+function shiftWallClock<T extends DailyCron | WeeklyCron | MonthlyCron>(
+  value: T,
+  offsetMin: number,
+): T {
+  const clock = shiftClock(value.hour, value.minute, offsetMin);
+  switch (value.kind) {
+    case "daily":
+      return { ...value, hour: clock.hour, minute: clock.minute };
+    case "weekly":
+      return {
+        ...value,
+        hour: clock.hour,
+        minute: clock.minute,
+        days: shiftWeekdays(value.days, clock.dayDelta),
+      };
+    case "monthly":
+      return {
+        ...value,
+        hour: clock.hour,
+        minute: clock.minute,
+        day: shiftMonthDay(value.day, clock.dayDelta),
+      };
+    default:
+      return assertNever(value, "wall-clock CronValue");
+  }
+}
+
+function fromUtcValue(value: CronValue): CronValue {
+  if (value.kind === "daily" || value.kind === "weekly" || value.kind === "monthly") {
+    return shiftWallClock(value, -tzOffsetMin());
+  }
+  return value;
+}
+
+function toUtcValue<T extends DailyCron | WeeklyCron | MonthlyCron>(value: T): T {
+  return shiftWallClock(value, tzOffsetMin());
 }
 
 function extractTime(value: CronValue): { hour: number; minute: number } {


### PR DESCRIPTION
## Summary
- 每天 / 每周 / 每月按浏览器本地时间填写, 写出 UTC cron
- 列表摘要与「下次执行」均为本地时刻
- 间隔不换算; 高级手写按 UTC

## Test plan
- [ ] UTC+8 新建每天 `00:00`, 下次执行为本地零点, 表达式为 `0 16 * * *`
- [ ] 打开该任务, 选择器仍显示 `00:00`
- [ ] 每周周一 `00:00`, 表达式星期为周日

Fix #115