### PR TITLE
fix: 允许配置 Agent 输出 token 上限

### DIFF
--- a/docs/dev/agent.md
+++ b/docs/dev/agent.md
@@ -87,4 +87,4 @@ SQL 非法或 SQLite 运行时错误 → 工具返回 `error` 字符串, **不**
 
 上游协议由 `hot.agent.api_type` 选择 (`runtime.build_model`): `chat` → Chat Completions; `response` → Responses; `anthropic` → Anthropic Messages. `base_url` / `api_key` / `model` 原样交给对应 Provider (Anthropic 需填 Anthropic 端点, 无隐式改写).
 
-思考强度: 全局 `hot.agent.thinking` 为默认 (`None` = 不传); 会话覆盖在 `meta.json`. 每回合经由 `model_settings` 注入 (含高 `max_tokens`); 运行使用无上限的 `UsageLimits`.
+思考强度: 全局 `hot.agent.thinking` 为默认 (`None` = 不传); 会话覆盖在 `meta.json`. 每回合经由 `model_settings` 注入 thinking 与 `hot.agent.max_tokens` (默认 128000, 避免提供商默认过小导致 length 截断; 超过模型上限时上游拒绝请求). 运行使用无上限的 `UsageLimits`.

--- a/src/amane/agent/runtime.py
+++ b/src/amane/agent/runtime.py
@@ -23,8 +23,6 @@ from .task_ops import build_task_ops_capability
 from .tool_names import ToolNameAlias
 from .tools import AgentDeps, build_explore_toolset
 
-# 避免使用提供商默认 max_tokens (过小会 length 截断且无正文).
-_AGENT_MAX_TOKENS = 128_000
 # 工具 / 输出校验重试: 框架默认 1, 此处拉高避免早停.
 _AGENT_RETRIES = 10_000
 # 关闭 request / tool_calls / token 等 UsageLimits (框架默认 request_limit=50).
@@ -97,8 +95,8 @@ def thinking_to_level(mode: AgentThinkingMode) -> ThinkingLevel:
 
 
 def resolve_model_settings(config: AgentConfig, *, session_thinking: AgentThinkingMode | None = None) -> ModelSettings:
-    """始终带高 max_tokens. ``session_thinking`` 为 None 表示继承 ``config.thinking``; 有效值仍为 None 时不传 thinking."""
-    settings: ModelSettings = {"max_tokens": _AGENT_MAX_TOKENS}
+    """始终注入 ``config.max_tokens`` (避免提供商默认过小导致 length 截断). ``session_thinking`` 为 None 表示继承 ``config.thinking``; 有效值仍为 None 时不传 thinking."""
+    settings: ModelSettings = {"max_tokens": config.max_tokens}
     effective = config.thinking if session_thinking is None else session_thinking
     if effective is not None:
         settings["thinking"] = thinking_to_level(effective)

--- a/src/amane/config/manager.py
+++ b/src/amane/config/manager.py
@@ -538,6 +538,9 @@ class AgentConfig(BaseModel):
     thinking: AgentThinkingMode | None = None
     """新建会话的回退默认; None 表示不传 thinking. 会话可在 meta 覆盖."""
 
+    max_tokens: int = Field(default=128_000, ge=1, le=1_000_000)
+    """单次回复的输出上限. 超过模型上限时上游拒绝请求."""
+
     rate_limit: float = Field(default=2.0, ge=0.1, le=100)
     sql_timeout_ms: int = Field(default=1000, ge=50, le=60_000, json_schema_extra={"x-hidden": True})
     """只读 SQL 默认超时 (毫秒). 超过须用户批准放宽."""

--- a/src/amane/config/manager.py
+++ b/src/amane/config/manager.py
@@ -538,7 +538,7 @@ class AgentConfig(BaseModel):
     thinking: AgentThinkingMode | None = None
     """新建会话的回退默认; None 表示不传 thinking. 会话可在 meta 覆盖."""
 
-    max_tokens: int = Field(default=128_000, ge=1, le=1_000_000)
+    max_tokens: int = Field(default=128_000, ge=1)
     """单次回复的输出上限. 超过模型上限时上游拒绝请求."""
 
     rate_limit: float = Field(default=2.0, ge=0.1, le=100)

--- a/tests/agent/test_runtime_model.py
+++ b/tests/agent/test_runtime_model.py
@@ -69,9 +69,9 @@ def test_resolve_model_settings(
     session_thinking: AgentThinkingMode | None,
     expected_thinking: object | None,
 ) -> None:
-    config = AgentConfig(thinking=global_thinking)
+    config = AgentConfig(thinking=global_thinking, max_tokens=65_536)
     settings = resolve_model_settings(config, session_thinking=session_thinking)
-    assert settings.get("max_tokens") == 128_000
+    assert settings.get("max_tokens") == 65_536
     if expected_thinking is None:
         assert "thinking" not in settings
     else:

--- a/tests/config/test_config_manager.py
+++ b/tests/config/test_config_manager.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from amane.app.bootstrap import build_safe_dirs
 from amane.config import (
     SAFE_DIRS_ALLOW_ALL,
+    AgentConfig,
     ColdSettings,
     ConfigManager,
     DownloadableResource,
@@ -143,6 +144,18 @@ class TestHotSettings:
         """worker.poll_interval > 10.0 被拒绝"""
         with pytest.raises(ValidationError, match=r"less than or equal to 10"):
             HotSettings(worker=WorkerConfig(poll_interval=11.0))
+
+    @pytest.mark.parametrize(
+        ("max_tokens", "match"),
+        [
+            (0, r"greater than or equal to 1"),
+            (-1, r"greater than or equal to 1"),
+            (1_000_001, r"less than or equal to 1000000"),
+        ],
+    )
+    def test_agent_max_tokens_out_of_range(self, max_tokens: int, match: str) -> None:
+        with pytest.raises(ValidationError, match=match):
+            AgentConfig(max_tokens=max_tokens)
 
 
 class TestScrapingDownloadResources:

--- a/tests/config/test_config_manager.py
+++ b/tests/config/test_config_manager.py
@@ -11,7 +11,6 @@ from pydantic import ValidationError
 from amane.app.bootstrap import build_safe_dirs
 from amane.config import (
     SAFE_DIRS_ALLOW_ALL,
-    AgentConfig,
     ColdSettings,
     ConfigManager,
     DownloadableResource,
@@ -144,18 +143,6 @@ class TestHotSettings:
         """worker.poll_interval > 10.0 被拒绝"""
         with pytest.raises(ValidationError, match=r"less than or equal to 10"):
             HotSettings(worker=WorkerConfig(poll_interval=11.0))
-
-    @pytest.mark.parametrize(
-        ("max_tokens", "match"),
-        [
-            (0, r"greater than or equal to 1"),
-            (-1, r"greater than or equal to 1"),
-            (1_000_001, r"less than or equal to 1000000"),
-        ],
-    )
-    def test_agent_max_tokens_out_of_range(self, max_tokens: int, match: str) -> None:
-        with pytest.raises(ValidationError, match=match):
-            AgentConfig(max_tokens=max_tokens)
 
 
 class TestScrapingDownloadResources:

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -5622,7 +5622,6 @@
           },
           "max_tokens": {
             "type": "integer",
-            "maximum": 1000000.0,
             "minimum": 1.0,
             "title": "Max Tokens",
             "default": 128000

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -5620,6 +5620,13 @@
               }
             ]
           },
+          "max_tokens": {
+            "type": "integer",
+            "maximum": 1000000.0,
+            "minimum": 1.0,
+            "title": "Max Tokens",
+            "default": 128000
+          },
           "rate_limit": {
             "type": "number",
             "maximum": 100.0,
@@ -7245,6 +7252,7 @@
               "api_type": "response",
               "base_url": "https://api.openai.com/v1",
               "model": "gpt-4o-mini",
+              "max_tokens": 128000,
               "rate_limit": 2.0,
               "sql_timeout_ms": 1000,
               "result_cache_ttl_s": 3600,

--- a/web/src/client/schemas.gen.ts
+++ b/web/src/client/schemas.gen.ts
@@ -594,7 +594,6 @@ export const AgentConfigSchema = {
         },
         max_tokens: {
             type: 'integer',
-            maximum: 1000000,
             minimum: 1,
             title: 'Max Tokens',
             default: 128000

--- a/web/src/client/schemas.gen.ts
+++ b/web/src/client/schemas.gen.ts
@@ -592,6 +592,13 @@ export const AgentConfigSchema = {
                 }
             ]
         },
+        max_tokens: {
+            type: 'integer',
+            maximum: 1000000,
+            minimum: 1,
+            title: 'Max Tokens',
+            default: 128000
+        },
         rate_limit: {
             type: 'number',
             maximum: 100,
@@ -2262,6 +2269,7 @@ export const HotSettingsSchema = {
                 api_type: 'response',
                 base_url: 'https://api.openai.com/v1',
                 model: 'gpt-4o-mini',
+                max_tokens: 128000,
                 rate_limit: 2,
                 sql_timeout_ms: 1000,
                 result_cache_ttl_s: 3600,

--- a/web/src/client/types.gen.ts
+++ b/web/src/client/types.gen.ts
@@ -312,6 +312,10 @@ export type AgentConfig = {
     model?: string;
     thinking?: AgentThinkingMode | null;
     /**
+     * Max Tokens
+     */
+    max_tokens?: number;
+    /**
      * Rate Limit
      */
     rate_limit?: number;

--- a/web/src/i18n/locales/en/settings.json
+++ b/web/src/i18n/locales/en/settings.json
@@ -608,6 +608,10 @@
           "xhigh": "Max"
         }
       },
+      "max_tokens": {
+        "label": "Max output tokens",
+        "description": "Per-reply output cap. The provider rejects values above the model's limit"
+      },
       "rate_limit": {
         "label": "Max requests per second",
         "description": "See the provider's docs; too high may trigger rate limiting"

--- a/web/src/i18n/locales/zh-CN/settings.json
+++ b/web/src/i18n/locales/zh-CN/settings.json
@@ -608,6 +608,10 @@
           "xhigh": "最高"
         }
       },
+      "max_tokens": {
+        "label": "最大输出 token",
+        "description": "单次回复的输出上限. 超过模型上限时上游拒绝请求"
+      },
       "rate_limit": {
         "label": "每秒请求上限",
         "description": "参考供应商说明, 过高可能触发限流"


### PR DESCRIPTION
## Summary
- Agent 每回合请求的 `max_tokens` 改为读取 `hot.agent.max_tokens` (默认仍为 128000)
- 设置页可配置该项, 以适配输出上限低于 128000 的模型 (例如 Agnes 2.5 为 65536)

## Test plan
- [ ] 设置 `max_tokens` 为 60000, Agent 对 Agnes 2.5 可正常回复
- [ ] 保持默认 128000, 原 OpenAI 兼容端点行为不变

Fix #122