### PR TITLE
fix: 原生监控删除事件按路径前缀清索引

### DIFF
--- a/docs/dev/task-system.md
+++ b/docs/dev/task-system.md
@@ -210,4 +210,4 @@ Watcher、Cron 与 Feed 分属独立循环: 秒级反应、分钟级 routine、�
 
 **归属随事件携带**: 每个监控根的 `_Handler` 绑定 `library_id`; 文件事件回调带上来源库, 新文件以此入库 (见 [data-model.md](data-model.md) Library 归属).
 
-目录移出本 watch 被 watchdog 折成 `DirDeletedEvent`, 与删除目录相同. Windows `ReadDirectoryChanges` 对目录发无扩展名的 `FileDeletedEvent`. Handler 处理上述事件: 按路径前缀丢掉未过防抖的文件创建 / 删除 / 移动, 防抖后按该库 `MediaFile.path` 前缀删除索引, 不遍历磁盘. 库内目录改名仍是 `DirMovedEvent` 加合成子文件 `FileMovedEvent`, 不按前缀删除. 目录创建仍忽略; 移入靠合成子文件 `FileCreatedEvent`. `.amane_trash` 下的目录事件忽略.
+删除事件一律按该库 `MediaFile.path` 前缀删除索引 (含路径自身, 因此单文件删除只命中这一条), 不遍历磁盘; 未过防抖的创建 / 删除 / 移动按同一前缀丢掉. Windows `ReadDirectoryChanges` 的删除通知不区分文件与目录, 与 `DirDeletedEvent` 同一处理. 库内目录改名仍是 `DirMovedEvent` 加合成子文件 `FileMovedEvent`, 不按前缀删除. 目录创建仍忽略; 移入靠合成子文件 `FileCreatedEvent`. `.amane_trash` 下的路径忽略.

--- a/docs/dev/task-system.md
+++ b/docs/dev/task-system.md
@@ -209,3 +209,5 @@ Watcher、Cron 与 Feed 分属独立循环: 秒级反应、分钟级 routine、�
 `watcher.use_polling` 在 NAS / Docker Desktop / WSL2 等 inotify 不可靠场景下打开. `debounce_seconds` 防止大文件写入途中提前刮削. 这三项 HotSettings 在进程启动时注入 WatcherService, 修改 TOML 后须重启才生效 (见 [config.md](config.md)); Library 级 `automation` / 路径 / `trailer_pattern` 则由 libraries 路由热增删监控根. `automation=none` 不监控; `watch` 只登记; `scrape` 登记后入队 SCRAPE. 三者都不自动 ORGANIZE.
 
 **归属随事件携带**: 每个监控根的 `_Handler` 绑定 `library_id`; 文件事件回调带上来源库, 新文件以此入库 (见 [data-model.md](data-model.md) Library 归属).
+
+目录移出本 watch 被 watchdog 折成 `DirDeletedEvent`, 与删除目录相同. Handler 处理该事件: 按路径前缀丢掉未过防抖的文件创建 / 删除 / 移动, 防抖后按该库 `MediaFile.path` 前缀删除索引, 不遍历磁盘. 库内目录改名仍是 `DirMovedEvent` 加合成子文件 `FileMovedEvent`, 不按前缀删除. 目录创建仍忽略; 移入靠合成子文件 `FileCreatedEvent`. `.amane_trash` 下的目录事件忽略.

--- a/docs/dev/task-system.md
+++ b/docs/dev/task-system.md
@@ -210,4 +210,4 @@ Watcher、Cron 与 Feed 分属独立循环: 秒级反应、分钟级 routine、�
 
 **归属随事件携带**: 每个监控根的 `_Handler` 绑定 `library_id`; 文件事件回调带上来源库, 新文件以此入库 (见 [data-model.md](data-model.md) Library 归属).
 
-目录移出本 watch 被 watchdog 折成 `DirDeletedEvent`, 与删除目录相同. Handler 处理该事件: 按路径前缀丢掉未过防抖的文件创建 / 删除 / 移动, 防抖后按该库 `MediaFile.path` 前缀删除索引, 不遍历磁盘. 库内目录改名仍是 `DirMovedEvent` 加合成子文件 `FileMovedEvent`, 不按前缀删除. 目录创建仍忽略; 移入靠合成子文件 `FileCreatedEvent`. `.amane_trash` 下的目录事件忽略.
+目录移出本 watch 被 watchdog 折成 `DirDeletedEvent`, 与删除目录相同. Windows `ReadDirectoryChanges` 对目录发无扩展名的 `FileDeletedEvent`. Handler 处理上述事件: 按路径前缀丢掉未过防抖的文件创建 / 删除 / 移动, 防抖后按该库 `MediaFile.path` 前缀删除索引, 不遍历磁盘. 库内目录改名仍是 `DirMovedEvent` 加合成子文件 `FileMovedEvent`, 不按前缀删除. 目录创建仍忽略; 移入靠合成子文件 `FileCreatedEvent`. `.amane_trash` 下的目录事件忽略.

--- a/src/amane/scheduler/service.py
+++ b/src/amane/scheduler/service.py
@@ -1,5 +1,7 @@
 import asyncio
 import contextlib
+from collections.abc import Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
@@ -10,12 +12,10 @@ from ..events import EventBus, EventType
 from ..handlers._common import register_media_file
 from ..handlers.models import ScrapePayload
 from ..parsing import parse_file_info
+from ..utils.path import path_is_under
 from .watcher import FileWatcher
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from pathlib import Path
-
     from ..db.repository import Repository
 
 logger = structlog.get_logger()
@@ -57,6 +57,7 @@ class WatcherService:
         return FileWatcher(
             on_file_found=self._on_file_found_sync,
             on_file_deleted=self._on_file_deleted_sync,
+            on_dir_deleted=self._on_dir_deleted_sync,
             on_file_moved=self._on_file_moved_sync,
             use_polling=self._use_polling,
             media_extensions=self._media_extensions,
@@ -167,6 +168,9 @@ class WatcherService:
     def _on_file_deleted_sync(self, path: Path, library_id: int) -> None:
         self._schedule_async(self._on_file_deleted(path))
 
+    def _on_dir_deleted_sync(self, path: Path, library_id: int) -> None:
+        self._schedule_async(self._delete_under(library_id, path))
+
     def _on_file_moved_sync(self, src: Path, dest: Path, library_id: int) -> None:
         self._schedule_async(self._on_file_moved(src, dest, library_id))
 
@@ -221,6 +225,14 @@ class WatcherService:
         logger.info("file removed from db", path=path_str, media_file_id=media.id)
 
         await self._event_bus.emit(EventType.FILE_REMOVED, {"path": path_str, "media_file_id": media.id})
+
+    async def _delete_under(self, library_id: int, root: Path) -> None:
+        files = await self._repo.list_media_files(library_id=library_id, limit=None)
+        for media in files:
+            if media.id is None:
+                continue
+            if path_is_under(media.path, root):
+                await self._on_file_deleted(Path(media.path))
 
     async def _on_file_moved(self, src: Path, dest: Path, library_id: int) -> None:
         src_str = str(src)

--- a/src/amane/scheduler/watcher.py
+++ b/src/amane/scheduler/watcher.py
@@ -55,6 +55,10 @@ class _Handler(FileSystemEventHandler):
             # 尚未处理的创建事件一并移除
             self._pending.pop(path_str, None)
             self._pending_deletes[path_str] = time.time()
+            return
+        # Windows ReadDirectoryChanges 对目录移出/删除发 FileDeletedEvent.
+        if path.suffix == "":
+            self._record_dir_delete(path_str)
 
     def on_moved(self, event):
         if not event.is_directory:

--- a/src/amane/scheduler/watcher.py
+++ b/src/amane/scheduler/watcher.py
@@ -46,19 +46,9 @@ class _Handler(FileSystemEventHandler):
             self._handle(str(event.src_path))
 
     def on_deleted(self, event):
-        path_str = str(event.src_path)
-        if event.is_directory:
-            self._record_dir_delete(path_str)
-            return
-        path = Path(path_str)
-        if self._matches(path):
-            # 尚未处理的创建事件一并移除
-            self._pending.pop(path_str, None)
-            self._pending_deletes[path_str] = time.time()
-            return
-        # Windows ReadDirectoryChanges 对目录移出/删除发 FileDeletedEvent.
-        if path.suffix == "":
-            self._record_dir_delete(path_str)
+        # 前缀含路径自身: 文件删除只命中这一条; 目录删除命中子树.
+        # Windows 删除通知不区分文件与目录, 一律按前缀处理.
+        self._record_prefix_delete(str(event.src_path))
 
     def on_moved(self, event):
         if not event.is_directory:
@@ -79,11 +69,11 @@ class _Handler(FileSystemEventHandler):
                 if self._matches(src):
                     self._pending_deletes[src_str] = time.time()
 
-    def _record_dir_delete(self, dir_str: str) -> None:
-        """目录移出本 watch 与删除目录均为 DirDeletedEvent; 按前缀清未提交事件."""
+    def _record_prefix_delete(self, dir_str: str) -> None:
+        """按路径前缀清未提交事件; 防抖后由服务端按索引前缀删除."""
         if is_in_trash(Path(dir_str)):
             return
-        # 已有更外层目录待删除时不必再记; 同一路径则刷新时间戳.
+        # 已有更外层路径待删除时不必再记; 同一路径则刷新时间戳.
         if any(
             path_is_under(dir_str, existing) and not path_is_under(existing, dir_str)
             for existing in self._pending_dir_deletes

--- a/src/amane/scheduler/watcher.py
+++ b/src/amane/scheduler/watcher.py
@@ -8,6 +8,8 @@ from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
 
 from ..library import MEDIA_EXTENSIONS, LibraryFileKind, LibraryScan
+from ..library.rules import is_in_trash
+from ..utils.path import path_is_under
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -36,6 +38,7 @@ class _Handler(FileSystemEventHandler):
         self._debounce_seconds = debounce_seconds
         self._pending: dict[str, float] = {}
         self._pending_deletes: dict[str, float] = {}
+        self._pending_dir_deletes: dict[str, float] = {}
         self._pending_moves: dict[str, tuple[str, float]] = {}  # dest -> (src, timestamp)
 
     def on_created(self, event):
@@ -43,13 +46,15 @@ class _Handler(FileSystemEventHandler):
             self._handle(str(event.src_path))
 
     def on_deleted(self, event):
-        if not event.is_directory:
-            path_str = str(event.src_path)
-            path = Path(path_str)
-            if self._matches(path):
-                # 尚未处理的创建事件一并移除
-                self._pending.pop(path_str, None)
-                self._pending_deletes[path_str] = time.time()
+        path_str = str(event.src_path)
+        if event.is_directory:
+            self._record_dir_delete(path_str)
+            return
+        path = Path(path_str)
+        if self._matches(path):
+            # 尚未处理的创建事件一并移除
+            self._pending.pop(path_str, None)
+            self._pending_deletes[path_str] = time.time()
 
     def on_moved(self, event):
         if not event.is_directory:
@@ -69,6 +74,34 @@ class _Handler(FileSystemEventHandler):
                 src = Path(src_str)
                 if self._matches(src):
                     self._pending_deletes[src_str] = time.time()
+
+    def _record_dir_delete(self, dir_str: str) -> None:
+        """目录移出本 watch 与删除目录均为 DirDeletedEvent; 按前缀清未提交事件."""
+        if is_in_trash(Path(dir_str)):
+            return
+        # 已有更外层目录待删除时不必再记; 同一路径则刷新时间戳.
+        if any(
+            path_is_under(dir_str, existing) and not path_is_under(existing, dir_str)
+            for existing in self._pending_dir_deletes
+        ):
+            self._drop_pending_under(dir_str)
+            return
+        self._drop_pending_under(dir_str)
+        self._pending_dir_deletes[dir_str] = time.time()
+
+    def _drop_pending_under(self, root: str) -> None:
+        self._pending = {path: ts for path, ts in self._pending.items() if not path_is_under(path, root)}
+        self._pending_deletes = {
+            path: ts for path, ts in self._pending_deletes.items() if not path_is_under(path, root)
+        }
+        self._pending_moves = {
+            dest: src_ts
+            for dest, src_ts in self._pending_moves.items()
+            if not path_is_under(dest, root) and not path_is_under(src_ts[0], root)
+        }
+        self._pending_dir_deletes = {
+            path: ts for path, ts in self._pending_dir_deletes.items() if not path_is_under(path, root)
+        }
 
     def _handle(self, path_str: str) -> None:
         path = Path(path_str)
@@ -102,6 +135,18 @@ class _Handler(FileSystemEventHandler):
         self._pending_deletes = remaining
         return ready
 
+    def get_ready_dir_deletes(self) -> list[Path]:
+        now = time.time()
+        ready = []
+        remaining = {}
+        for path_str, timestamp in self._pending_dir_deletes.items():
+            if now - timestamp >= self._debounce_seconds:
+                ready.append(Path(path_str))
+            else:
+                remaining[path_str] = timestamp
+        self._pending_dir_deletes = remaining
+        return ready
+
     def get_ready_moves(self) -> list[tuple[Path, Path]]:
         now = time.time()
         ready = []
@@ -127,6 +172,7 @@ class FileWatcher:
         self,
         on_file_found: Callable[[Path, int], None],
         on_file_deleted: Callable[[Path, int], None] | None = None,
+        on_dir_deleted: Callable[[Path, int], None] | None = None,
         on_file_moved: Callable[[Path, Path, int], None] | None = None,
         use_polling: bool = False,
         media_extensions: list[str] | None = None,
@@ -135,6 +181,7 @@ class FileWatcher:
     ):
         self._on_file_found = on_file_found
         self._on_file_deleted = on_file_deleted
+        self._on_dir_deleted = on_dir_deleted
         self._on_file_moved = on_file_moved
         self._use_polling = use_polling
         self._media_extensions = frozenset(media_extensions) if media_extensions else MEDIA_EXTENSIONS
@@ -201,13 +248,17 @@ class FileWatcher:
         """刷新已过防抖窗口的事件并调用对应回调."""
         ready_files = []
         for handler in self._handlers:
-            for path in handler.get_ready_files():
-                self._on_file_found(path, handler.library_id)
-                ready_files.append(path)
+            # 目录前缀删除须先于创建: 同窗口内重建的文件应在清索引之后重新登记.
+            if self._on_dir_deleted:
+                for path in handler.get_ready_dir_deletes():
+                    self._on_dir_deleted(path, handler.library_id)
             if self._on_file_deleted:
                 for path in handler.get_ready_deletes():
                     self._on_file_deleted(path, handler.library_id)
             if self._on_file_moved:
                 for src, dest in handler.get_ready_moves():
                     self._on_file_moved(src, dest, handler.library_id)
+            for path in handler.get_ready_files():
+                self._on_file_found(path, handler.library_id)
+                ready_files.append(path)
         return ready_files

--- a/src/amane/utils/path.py
+++ b/src/amane/utils/path.py
@@ -42,6 +42,17 @@ def is_any_descendant(p: str | Path, *parents: str | Path) -> bool:
     return any(is_descendant(p, parent) for parent in parents)
 
 
+def path_is_under(path: str | Path, root: str | Path) -> bool:
+    """字面路径是否为 root 自身或子孙.
+
+    不做 realpath: 目录移出或删除后源路径已不存在, 仍须能按索引前缀匹配.
+    比较前 NFC、``normcase``、``normpath``, 避免 ``/a/bar`` 命中 ``/a/barbar``.
+    """
+    candidate = Path(os.path.normcase(os.path.normpath(nfc_path(os.fspath(path)))))
+    base = Path(os.path.normcase(os.path.normpath(nfc_path(os.fspath(root)))))
+    return candidate == base or base in candidate.parents
+
+
 def nfc_path(path: str) -> str:
     """库内路径身份一律 NFC.
 

--- a/tests/scheduler/test_watcher.py
+++ b/tests/scheduler/test_watcher.py
@@ -24,6 +24,7 @@ from amane.events import EventBus
 from amane.library import LibraryScan
 from amane.scheduler.service import WatcherService
 from amane.scheduler.watcher import DEBOUNCE_SECONDS, FileWatcher, _Handler
+from amane.utils.path import path_is_under
 from tests.helpers import await_for, wait_for
 
 
@@ -195,6 +196,14 @@ class TestHandler:
         handler.on_deleted(DirDeletedEvent(src_path="/lib/show"))
         assert handler._pending_moves == {}
         assert "/lib/show" in handler._pending_dir_deletes
+
+    def test_on_deleted_extensionless_non_media_is_dir_delete(self):
+        """无扩展名且非媒体: 按目录删除 (Windows 对目录发 FileDeletedEvent)."""
+        handler = _Handler(library_id=1)
+        handler.on_created(FileCreatedEvent(src_path="/lib/show/a.mp4"))
+        handler.on_deleted(FileDeletedEvent(src_path="/lib/show"))
+        assert "/lib/show" in handler._pending_dir_deletes
+        assert "/lib/show/a.mp4" not in handler._pending
 
     def test_on_deleted_removes_from_pending_creates(self):
         """文件创建后立即删除: 从 pending 中移除, 添加到 pending_deletes"""
@@ -690,6 +699,8 @@ class TestFileWatcherTmpFiles:
         try:
             shutil.move(str(nested), str(outside / "show"))
             handler = watcher._handlers[0]
-            wait_for(lambda: str(nested) in handler._pending_dir_deletes)
+            wait_for(
+                lambda: any(path_is_under(p, nested) and path_is_under(nested, p) for p in handler._pending_dir_deletes)
+            )
         finally:
             watcher.stop()

--- a/tests/scheduler/test_watcher.py
+++ b/tests/scheduler/test_watcher.py
@@ -141,14 +141,16 @@ class TestHandler:
         handler.on_moved(FileMovedEvent(src_path="/tmp/old.mkv", dest_path="/tmp/movie.mkv"))
         assert "/tmp/movie.mkv" in handler._pending_moves
 
-    def test_on_deleted_adds_to_pending_deletes(self):
+    def test_on_deleted_file_records_prefix(self):
         handler = _Handler(library_id=1)
         handler.on_deleted(FileDeletedEvent(src_path="/tmp/video.mp4"))
-        assert "/tmp/video.mp4" in handler._pending_deletes
+        assert "/tmp/video.mp4" in handler._pending_dir_deletes
+        assert handler._pending_deletes == {}
 
-    def test_on_deleted_ignores_non_media(self):
+    def test_on_deleted_non_media_file_records_prefix(self):
         handler = _Handler(library_id=1)
         handler.on_deleted(FileDeletedEvent(src_path="/tmp/notes.txt"))
+        assert "/tmp/notes.txt" in handler._pending_dir_deletes
         assert handler._pending_deletes == {}
 
     def test_on_deleted_directory_records_prefix(self):
@@ -197,22 +199,30 @@ class TestHandler:
         assert handler._pending_moves == {}
         assert "/lib/show" in handler._pending_dir_deletes
 
-    def test_on_deleted_extensionless_non_media_is_dir_delete(self):
-        """无扩展名且非媒体: 按目录删除 (Windows 对目录发 FileDeletedEvent)."""
+    def test_on_deleted_file_event_is_prefix(self):
         handler = _Handler(library_id=1)
         handler.on_created(FileCreatedEvent(src_path="/lib/show/a.mp4"))
         handler.on_deleted(FileDeletedEvent(src_path="/lib/show"))
         assert "/lib/show" in handler._pending_dir_deletes
         assert "/lib/show/a.mp4" not in handler._pending
 
+    def test_on_deleted_file_event_dotted_dir_name_is_prefix(self):
+        """Windows 对目录发 FileDeletedEvent; 目录名带点仍按前缀."""
+        handler = _Handler(library_id=1)
+        handler.on_created(FileCreatedEvent(src_path="/lib/Season1.mkv/a.mp4"))
+        handler.on_deleted(FileDeletedEvent(src_path="/lib/Season1.mkv"))
+        assert "/lib/Season1.mkv" in handler._pending_dir_deletes
+        assert "/lib/Season1.mkv/a.mp4" not in handler._pending
+
     def test_on_deleted_removes_from_pending_creates(self):
-        """文件创建后立即删除: 从 pending 中移除, 添加到 pending_deletes"""
+        """文件创建后立即删除: 从 pending 中移除, 记为前缀删除."""
         handler = _Handler(library_id=1)
         handler.on_created(FileCreatedEvent(src_path="/tmp/video.mp4"))
         assert "/tmp/video.mp4" in handler._pending
         handler.on_deleted(FileDeletedEvent(src_path="/tmp/video.mp4"))
         assert "/tmp/video.mp4" not in handler._pending
-        assert "/tmp/video.mp4" in handler._pending_deletes
+        assert "/tmp/video.mp4" in handler._pending_dir_deletes
+        assert handler._pending_deletes == {}
 
     def test_get_ready_deletes_after_debounce(self):
         handler = _Handler(library_id=1)
@@ -514,6 +524,19 @@ class TestWatcherService:
         assert await repo.get_media_file_by_path(str(video)) is None
         assert await repo.get_media_file_by_path(str(sibling)) is not None
         assert await repo.get_media_file_by_path(str(other_video)) is not None
+
+    @pytest.mark.asyncio(loop_scope="function")
+    async def test_delete_under_file_path_only_self(self, service, repo: Repository, tmp_path: Path):
+        """文件路径当前缀时只命中自身, 不碰到兄弟文件."""
+        lib = await repo.create_library(name="t", path=str(tmp_path), automation=LibraryAutomation.WATCH)
+        assert lib.id is not None
+        video = tmp_path / "a.mp4"
+        sibling = tmp_path / "b.mp4"
+        await repo.create_media_file(library_id=lib.id, path=str(video))
+        await repo.create_media_file(library_id=lib.id, path=str(sibling))
+        await service._delete_under(lib.id, video)
+        assert await repo.get_media_file_by_path(str(video)) is None
+        assert await repo.get_media_file_by_path(str(sibling)) is not None
 
     @pytest.mark.asyncio(loop_scope="function")
     async def test_dir_delete_flushes_prefixed_index(self, service, repo: Repository, tmp_path: Path):

--- a/tests/scheduler/test_watcher.py
+++ b/tests/scheduler/test_watcher.py
@@ -8,7 +8,14 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel
-from watchdog.events import DirCreatedEvent, FileCreatedEvent, FileDeletedEvent, FileMovedEvent
+from watchdog.events import (
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileMovedEvent,
+)
 from watchdog.observers.polling import PollingObserver
 
 from amane.db.repository import Repository
@@ -143,6 +150,52 @@ class TestHandler:
         handler.on_deleted(FileDeletedEvent(src_path="/tmp/notes.txt"))
         assert handler._pending_deletes == {}
 
+    def test_on_deleted_directory_records_prefix(self):
+        handler = _Handler(library_id=1)
+        handler.on_created(FileCreatedEvent(src_path="/lib/show/a.mp4"))
+        handler.on_deleted(DirDeletedEvent(src_path="/lib/show"))
+        assert "/lib/show" in handler._pending_dir_deletes
+        assert "/lib/show/a.mp4" not in handler._pending
+        assert handler._pending_deletes == {}
+
+    def test_on_deleted_directory_keeps_sibling_prefix(self):
+        handler = _Handler(library_id=1)
+        handler.on_created(FileCreatedEvent(src_path="/lib/show2/a.mp4"))
+        handler.on_deleted(DirDeletedEvent(src_path="/lib/show"))
+        assert "/lib/show2/a.mp4" in handler._pending
+        assert "/lib/show" in handler._pending_dir_deletes
+
+    def test_on_deleted_directory_ignores_trash(self):
+        handler = _Handler(library_id=1)
+        handler.on_deleted(DirDeletedEvent(src_path="/lib/.amane_trash/old"))
+        assert handler._pending_dir_deletes == {}
+
+    def test_on_deleted_nested_dir_skipped_if_parent_pending(self):
+        handler = _Handler(library_id=1)
+        handler.on_deleted(DirDeletedEvent(src_path="/lib/show"))
+        handler.on_deleted(DirDeletedEvent(src_path="/lib/show/nested"))
+        assert list(handler._pending_dir_deletes) == ["/lib/show"]
+
+    def test_on_deleted_parent_dir_replaces_nested(self):
+        handler = _Handler(library_id=1)
+        handler.on_deleted(DirDeletedEvent(src_path="/lib/show/nested"))
+        handler.on_deleted(DirDeletedEvent(src_path="/lib/show"))
+        assert "/lib/show" in handler._pending_dir_deletes
+        assert "/lib/show/nested" not in handler._pending_dir_deletes
+
+    def test_on_moved_directory_ignored(self):
+        handler = _Handler(library_id=1)
+        handler.on_moved(DirMovedEvent(src_path="/lib/show", dest_path="/lib/renamed"))
+        assert handler._pending_dir_deletes == {}
+        assert handler._pending_moves == {}
+
+    def test_on_deleted_directory_drops_pending_move(self):
+        handler = _Handler(library_id=1)
+        handler.on_moved(FileMovedEvent(src_path="/lib/show/old.mp4", dest_path="/lib/show/new.mp4"))
+        handler.on_deleted(DirDeletedEvent(src_path="/lib/show"))
+        assert handler._pending_moves == {}
+        assert "/lib/show" in handler._pending_dir_deletes
+
     def test_on_deleted_removes_from_pending_creates(self):
         """文件创建后立即删除: 从 pending 中移除, 添加到 pending_deletes"""
         handler = _Handler(library_id=1)
@@ -213,6 +266,20 @@ class TestFileWatcher:
         assert ready[0] == Path(test_file)
         assert len(received) == 1
         assert received[0] == Path(test_file)
+
+    def test_check_debounced_dir_delete_callback(self, tmp_path: Path):
+        deleted: list[tuple[Path, int]] = []
+        watcher = FileWatcher(
+            observer_timeout=0.1,
+            on_file_found=lambda p, _lib: None,
+            on_dir_deleted=lambda p, lib: deleted.append((p, lib)),
+        )
+        watcher.watch(str(tmp_path), library_id=1)
+        handler = watcher._handlers[0]
+        target = tmp_path / "show"
+        handler._pending_dir_deletes[str(target)] = time.time() - DEBOUNCE_SECONDS - 1
+        watcher.check_debounced()
+        assert deleted == [(target, 1)]
 
     def test_multiple_watch_paths(self, tmp_path: Path):
         dir1 = tmp_path / "dir1"
@@ -422,6 +489,41 @@ class TestWatcherService:
         await service._on_file_deleted(test_file)  # 不应抛出
 
     @pytest.mark.asyncio(loop_scope="function")
+    async def test_delete_under_removes_prefix_only(self, service, repo: Repository, tmp_path: Path):
+        lib = await repo.create_library(name="t", path=str(tmp_path), automation=LibraryAutomation.WATCH)
+        other = await repo.create_library(name="o", path=str(tmp_path / "other"), automation=LibraryAutomation.WATCH)
+        assert lib.id is not None
+        assert other.id is not None
+        nested = tmp_path / "show"
+        video = nested / "a.mp4"
+        sibling = tmp_path / "show2" / "b.mp4"
+        other_video = tmp_path / "other" / "c.mp4"
+        await repo.create_media_file(library_id=lib.id, path=str(video))
+        await repo.create_media_file(library_id=lib.id, path=str(sibling))
+        await repo.create_media_file(library_id=other.id, path=str(other_video))
+        await service._delete_under(lib.id, nested)
+        assert await repo.get_media_file_by_path(str(video)) is None
+        assert await repo.get_media_file_by_path(str(sibling)) is not None
+        assert await repo.get_media_file_by_path(str(other_video)) is not None
+
+    @pytest.mark.asyncio(loop_scope="function")
+    async def test_dir_delete_flushes_prefixed_index(self, service, repo: Repository, tmp_path: Path):
+        lib = await repo.create_library(name="t", path=str(tmp_path), automation=LibraryAutomation.WATCH)
+        assert lib.id is not None
+        nested = tmp_path / "show"
+        video = nested / "a.mp4"
+        await repo.create_media_file(library_id=lib.id, path=str(video))
+        await service.start()
+        handler = service._watcher._handlers[0]
+        handler._pending_dir_deletes[str(nested)] = time.time() - DEBOUNCE_SECONDS - 1
+
+        async def gone() -> bool:
+            return await repo.get_media_file_by_path(str(video)) is None
+
+        assert await await_for(gone)
+        await service.stop()
+
+    @pytest.mark.asyncio(loop_scope="function")
     async def test_on_file_moved_updates_path(self, service, repo: Repository, tmp_path: Path):
         """文件移动时更新 DB 中的路径"""
         src = tmp_path / "old.mp4"
@@ -568,5 +670,26 @@ class TestFileWatcherTmpFiles:
             # PollingObserver 通过 on_created 检测新文件;
             # 原生 observer 通过 on_moved 检测 (同文件系统 rename)
             wait_for(lambda: str(dest) in handler._pending)
+        finally:
+            watcher.stop()
+
+    @pytest.mark.parametrize("use_polling", [True, False])
+    def test_moved_out_directory_records_dir_delete(self, tmp_path: Path, use_polling: bool):
+        """目录移出监控根: 源侧记目录删除, 不依赖子文件逐条删除."""
+        watched = tmp_path / "lib"
+        outside = tmp_path / "out"
+        watched.mkdir()
+        outside.mkdir()
+        nested = watched / "show"
+        nested.mkdir()
+        (nested / "a.mp4").write_bytes(b"\x00" * 64)
+
+        watcher = FileWatcher(observer_timeout=0.1, on_file_found=lambda p, _lib: None, use_polling=use_polling)
+        watcher.watch(str(watched), library_id=1)
+        watcher.start()
+        try:
+            shutil.move(str(nested), str(outside / "show"))
+            handler = watcher._handlers[0]
+            wait_for(lambda: str(nested) in handler._pending_dir_deletes)
         finally:
             watcher.stop()

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from amane.utils.path import existing_disk_path, is_descendant, nfc_path, path_forms
+from amane.utils.path import existing_disk_path, is_descendant, nfc_path, path_forms, path_is_under
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="此测试不适用于 Windows")
@@ -104,6 +104,23 @@ _NFD_JI = "\u3057\u3099"
 def test_nfc_path(raw: str, want: str) -> None:
     assert nfc_path(raw) == want
     assert nfc_path(raw) == nfc_path(nfc_path(raw))
+
+
+@pytest.mark.parametrize(
+    ("path", "root", "want"),
+    [
+        ("/lib/show/a.mp4", "/lib/show", True),
+        ("/lib/show", "/lib/show", True),
+        ("/lib/show/nested/a.mp4", "/lib/show", True),
+        ("/lib/show2/a.mp4", "/lib/show", False),
+        ("/lib/showcase/a.mp4", "/lib/show", False),
+        ("/lib/a.mp4", "/lib/show", False),
+        ("/lib/show", "/lib/show/nested", False),
+        (f"/lib/{_NFD_JI}/a.mp4", f"/lib/{_NFC_JI}", True),
+    ],
+)
+def test_path_is_under(path: str, root: str, want: bool) -> None:
+    assert path_is_under(path, root) is want
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- 原生 watchdog 把目录移出本 watch 折成 `DirDeletedEvent`, 且不为子文件合成删除; 此前 handler 忽略目录事件, 源库索引残留.
- 处理该事件: 按路径前缀丢掉未过防抖的文件事件, 防抖后按该库 `MediaFile.path` 前缀删除索引, 不遍历已不存在的源目录. 库内目录改名仍走既有 `FileMovedEvent`.
- 目录创建仍忽略; 移入继续依赖 watchdog 合成的子文件 `FileCreatedEvent`. `.amane_trash` 下的目录事件忽略.

## Test plan
- [ ] 单文件跨库 / 移出库: 源库删除、目标库创建 (既有行为不变)
- [ ] 整目录移出库或 `rm -rf` 子目录: 源库该前缀下索引被删除, 兄弟路径 `show` / `show2` 互不影响
- [ ] 库内目录改名: 子文件路径更新, 不按前缀删除
- [ ] `.amane_trash` 下目录删除不触发前缀清理